### PR TITLE
Fix cascade window behavior

### DIFF
--- a/MarkEditMac/Base.lproj/Main.storyboard
+++ b/MarkEditMac/Base.lproj/Main.storyboard
@@ -775,7 +775,7 @@
         <scene sceneID="R2V-B0-nI4">
             <objects>
                 <windowController storyboardIdentifier="EditorWindowController" id="jGA-0Y-lOj" userLabel="Editor Window Controller" customClass="EditorWindowController" customModule="MarkEdit" customModuleProvider="target" sceneMemberID="viewController">
-                    <window key="window" title="Window" separatorStyle="line" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" visibleAtLaunch="NO" frameAutosaveName="EditorWindow" animationBehavior="default" toolbarStyle="unified" id="Ckk-yw-fiv" customClass="EditorWindow" customModule="MarkEdit" customModuleProvider="target">
+                    <window key="window" title="Window" separatorStyle="line" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" visibleAtLaunch="NO" frameAutosaveName="" animationBehavior="default" toolbarStyle="unified" id="Ckk-yw-fiv" customClass="EditorWindow" customModule="MarkEdit" customModuleProvider="target">
                         <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES" fullSizeContentView="YES"/>
                         <rect key="contentRect" x="89" y="664" width="720" height="480"/>
                         <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1027"/>

--- a/MarkEditMac/Sources/Editor/EditorWindowController.swift
+++ b/MarkEditMac/Sources/Editor/EditorWindowController.swift
@@ -16,10 +16,17 @@ final class EditorWindowController: NSWindowController, NSWindowDelegate {
     super.windowDidLoad()
     window?.minSize = CGSize(width: 240, height: 0)
     window?.backgroundColor = .controlBackgroundColor
+
+    windowFrameAutosaveName = "Editor"
+    window?.setFrameUsingName(windowFrameAutosaveName)
   }
 
   func windowDidBecomeMain(_ notification: Notification) {
     NSApplication.shared.closeOpenPanels()
+  }
+
+  func windowDidResize(_ notification: Notification) {
+    window?.saveFrame(usingName: windowFrameAutosaveName)
   }
 
   func windowWillClose(_ notification: Notification) {


### PR DESCRIPTION
Main.storyboard has `frameAutosaveName="EditorWindow"`, but it doesn't work very well.