### PR TITLE
New option to overwrite NSQuitAlwaysKeepsWindows

### DIFF
--- a/MarkEditMac/Resources/zh-Hans.lproj/Localizable.strings
+++ b/MarkEditMac/Resources/zh-Hans.lproj/Localizable.strings
@@ -190,6 +190,9 @@
 /* Button title, move to the previous item */
 "Previous" = "上一个";
 
+/* Whether to keep windows when quit the app */
+"Quit always keeps windows" = "退出时总是保留窗口";
+
 /* Toolbar item to toggle blockquote */
 "Quote" = "引用";
 
@@ -285,6 +288,9 @@
 
 /* Window title for window settings */
 "Window" = "窗口";
+
+/* Label for window restoration options */
+"Window Restoration:" = "窗口恢复：";
 
 /* Line endings used on Windows */
 "Windows (CRLF)" = "Windows (CRLF)";

--- a/MarkEditMac/Resources/zh-Hant.lproj/Localizable.strings
+++ b/MarkEditMac/Resources/zh-Hant.lproj/Localizable.strings
@@ -190,6 +190,9 @@
 /* Button title, move to the previous item */
 "Previous" = "上一個";
 
+/* Whether to keep windows when quit the app */
+"Quit always keeps windows" = "退出時總是保留視窗";
+
 /* Toolbar item to toggle blockquote */
 "Quote" = "引用";
 
@@ -285,6 +288,9 @@
 
 /* Window title for window settings */
 "Window" = "視窗";
+
+/* Label for window restoration options */
+"Window Restoration:" = "視窗恢復：";
 
 /* Line endings used on Windows */
 "Windows (CRLF)" = "Windows (CRLF)";

--- a/MarkEditMac/Sources/Main/AppPreferences.swift
+++ b/MarkEditMac/Sources/Main/AppPreferences.swift
@@ -30,6 +30,15 @@ enum AppPreferences {
         performUpdates { $0.setDefaultLineBreak(defaultLineEndings.characters) }
       }
     }
+
+    static var quitAlwaysKeepsWindows: Bool {
+      get {
+        UserDefaults.standard.bool(forKey: "NSQuitAlwaysKeepsWindows")
+      }
+      set {
+        UserDefaults.standard.set(newValue, forKey: "NSQuitAlwaysKeepsWindows")
+      }
+    }
   }
 
   enum Editor {

--- a/MarkEditMac/Sources/Main/AppResources.swift
+++ b/MarkEditMac/Sources/Main/AppResources.swift
@@ -115,6 +115,8 @@ enum Localized {
     static let light = String(localized: "Light", comment: "Always use light mode for the app")
     static let dark = String(localized: "Dark", comment: "Always use dark mode for the app")
     static let newWindowBehavior = String(localized: "New Window Behavior:", comment: "Behavior when creating new windows")
+    static let windowRestoration = String(localized: "Window Restoration:", comment: "Label for window restoration options")
+    static let quitAlwaysKeepsWindows = String(localized: "Quit always keeps windows", comment: "Whether to keep windows when quit the app")
     static let defaultTextEncoding = String(localized: "Default Text Encoding:", comment: "Text encoding for opening and saving files")
     static let defaultLineEndings = String(localized: "Default Line Endings:", comment: "Line endings for creating new files")
     static let macOSLineEndings = String(localized: "macOS / Unix (LF)", comment: "Line endings used on macOS and Unix")

--- a/MarkEditMac/Sources/Settings/GeneralSettingsView.swift
+++ b/MarkEditMac/Sources/Settings/GeneralSettingsView.swift
@@ -12,6 +12,7 @@ import MarkEditKit
 struct GeneralSettingsView: View {
   @State private var appearance = AppPreferences.General.appearance
   @State private var newWindowBehavior = AppPreferences.General.newWindowBehavior
+  @State private var quitAlwaysKeepsWindows = AppPreferences.General.quitAlwaysKeepsWindows
   @State private var defaultTextEncoding = AppPreferences.General.defaultTextEncoding
   @State private var defaultLineEndings = AppPreferences.General.defaultLineEndings
 
@@ -38,6 +39,12 @@ struct GeneralSettingsView: View {
           AppPreferences.General.newWindowBehavior = $0
         }
         .formMenuPicker()
+
+        Toggle(Localized.Settings.quitAlwaysKeepsWindows, isOn: $quitAlwaysKeepsWindows)
+          .onChange(of: quitAlwaysKeepsWindows) {
+            AppPreferences.General.quitAlwaysKeepsWindows = $0
+          }
+          .formLabel(Localized.Settings.windowRestoration)
       }
 
       Section {


### PR DESCRIPTION
This option requires the next launch to take effect. To keep it simple, we don't quite want to introduce a dialog to confirm.