### PR TITLE
More native looking field for font picker

### DIFF
--- a/MarkEditMac/Modules/Sources/FontPicker/FontPicker.swift
+++ b/MarkEditMac/Modules/Sources/FontPicker/FontPicker.swift
@@ -38,7 +38,7 @@ public struct FontPicker: View {
           .padding(.horizontal, 5)
           .truncationMode(.middle)
       }
-      .frame(width: 180, height: 19, alignment: .center)
+      .frame(width: 190, height: 19, alignment: .center)
 
       Stepper(
         value: $selectedFontSize,


### PR DESCRIPTION
To have a native-looking bezel, use a non-editable `TextField` as the background.