### PR TITLE
Improve how active line indicator is disabled

### DIFF
--- a/CoreEditor/src/config.ts
+++ b/CoreEditor/src/config.ts
@@ -46,7 +46,6 @@ export interface Dynamics {
   theme: Compartment;
   gutters?: Compartment;
   invisibles?: Compartment;
-  activeLine?: Compartment;
   lineWrapping?: Compartment;
   lineEndings?: Compartment;
   indentUnit?: Compartment;

--- a/CoreEditor/src/extensions.ts
+++ b/CoreEditor/src/extensions.ts
@@ -30,7 +30,6 @@ import { observeChanges, interceptInputs } from './modules/input';
 const theme = new Compartment;
 const gutters = new Compartment;
 const invisibles = new Compartment;
-const activeLine = new Compartment;
 const lineWrapping = new Compartment;
 const lineEndings = new Compartment;
 const indentUnit = new Compartment;
@@ -39,7 +38,6 @@ window.dynamics = {
   theme,
   gutters,
   invisibles,
-  activeLine,
   lineWrapping,
   lineEndings,
   indentUnit,
@@ -60,7 +58,7 @@ export function extensions(options: { lineBreak?: string }) {
     closeBrackets(),
     rectangularSelection(),
     crosshairCursor(),
-    activeLine.of(window.config.showActiveLineIndicator ? highlightActiveLine() : []),
+    highlightActiveLine(),
     highlightActiveLineGutter(),
     highlightSelectionMatches(),
     localizePhrases(),

--- a/CoreEditor/src/styling/config.ts
+++ b/CoreEditor/src/styling/config.ts
@@ -1,4 +1,4 @@
-import { EditorView, highlightActiveLine } from '@codemirror/view';
+import { EditorView } from '@codemirror/view';
 import { EditorTheme, loadTheme } from './themes';
 import { Config } from '../config';
 import { styleSheets } from '../common/store';
@@ -17,6 +17,7 @@ export default interface StyleSheets {
   fontFamily?: HTMLStyleElement;
   fontSize?: HTMLStyleElement;
   focusMode?: HTMLStyleElement;
+  activeLineDisabler?: HTMLStyleElement;
   lineHeight?: HTMLStyleElement;
 }
 
@@ -100,12 +101,16 @@ export function setShowLineNumbers(enabled: boolean) {
 }
 
 export function setShowActiveLineIndicator(enabled: boolean) {
-  const editor = window.editor as EditorView | null;
-  if (typeof editor?.dispatch === 'function') {
-    editor.dispatch({
-      effects: window.dynamics.activeLine?.reconfigure(enabled ? highlightActiveLine() : []),
-    });
+  if (styleSheets.activeLineDisabler === undefined) {
+    const style = document.createElement('style');
+    style.textContent = '.cm-activeLine { background-color: unset !important }';
+
+    style.disabled = true;
+    styleSheets.activeLineDisabler = style;
+    document.head.appendChild(style);
   }
+
+  styleSheets.activeLineDisabler.disabled = enabled;
 }
 
 export function setShowInvisibles(enabled: boolean) {


### PR DESCRIPTION
Toggling the `highlightActiveLine` would also make focus mode hard to read, use a css rule instead.