### PR TITLE
Better tree-shaking for the @light target

### DIFF
--- a/CoreEditor/index.ts
+++ b/CoreEditor/index.ts
@@ -19,6 +19,7 @@ import { NativeModulePreview } from './src/bridge/native/preview';
 
 import * as core from './src/core';
 import * as styling from './src/styling/config';
+import * as themes from './src/styling/themes';
 import * as events from './src/dom/events';
 
 // "{{EDITOR_CONFIG}}" will be replaced with a JSON literal in production
@@ -69,5 +70,5 @@ window.onload = () => {
   }
 };
 
-styling.setUp(config);
+styling.setUp(config, themes.loadTheme(config.theme).accentColor);
 events.startObserving();

--- a/CoreEditor/src/@light/index.ts
+++ b/CoreEditor/src/@light/index.ts
@@ -5,7 +5,9 @@ import { markdown, markdownLanguage } from '../@vendor/lang-markdown';
 import { Config } from '../config';
 import { markdownExtensions, renderExtensions } from '../styling/markdown';
 
-import { loadTheme } from '../styling/themes';
+import GitHubLight from '../styling/themes/github-light';
+import GitHubDark from '../styling/themes/github-dark';
+
 import * as styling from '../styling/config';
 
 // "{{EDITOR_CONFIG}}" will be replaced with a JSON literal
@@ -38,7 +40,7 @@ const doc = config.text;
 const parent = document.querySelector('#editor') ?? document.body;
 
 window.editor = new EditorView({ doc, parent, extensions });
-styling.setUp(config);
+styling.setUp(config, loadTheme(config.theme).accentColor);
 
 // To keep the app size smaller, we don't have bridge here,
 // inject function to window directly.
@@ -46,3 +48,13 @@ styling.setUp(config);
 (window as any).setTheme = (name: string) => {
   styling.setTheme(loadTheme(name));
 };
+
+// There're only two themes in the preview extension,
+// use a simplified "loadTheme" to avoid bundling unused themes.
+function loadTheme(name: string) {
+  if (name === 'github-dark') {
+    return GitHubDark();
+  } else {
+    return GitHubLight();
+  }
+}

--- a/CoreEditor/src/core.ts
+++ b/CoreEditor/src/core.ts
@@ -3,6 +3,7 @@ import { extensions } from './extensions';
 import { editedState } from './common/store';
 
 import * as styling from './styling/config';
+import * as themes from './styling/themes';
 import * as lineEndings from './modules/lineEndings';
 
 /**
@@ -31,7 +32,7 @@ export function resetEditor(doc: string) {
   fixWebKitWheelIssues(scrollDOM);
 
   // Recofigure, window.config might have changed
-  styling.setUp(window.config);
+  styling.setUp(window.config, themes.loadTheme(window.config.theme).accentColor);
 
   // After calling editor.focus(), the selection is set to [Ln 1, Col 1]
   window.nativeModules.core.notifySelectionDidChange({

--- a/CoreEditor/src/styling/config.ts
+++ b/CoreEditor/src/styling/config.ts
@@ -1,5 +1,5 @@
 import { EditorView } from '@codemirror/view';
-import { EditorTheme, loadTheme } from './themes';
+import { EditorTheme } from './themes';
 import { Config } from '../config';
 import { styleSheets } from '../common/store';
 import { gutterExtensions } from './nodes/gutter';
@@ -21,8 +21,8 @@ export default interface StyleSheets {
   lineHeight?: HTMLStyleElement;
 }
 
-export function setUp(config: Config) {
-  setAccentColor(loadTheme(config.theme).accentColor);
+export function setUp(config: Config, accentColor: string) {
+  setAccentColor(accentColor);
   setFontFamily(config.fontFamily);
   setFontSize(config.fontSize);
   setFocusMode(config.focusMode);


### PR DESCRIPTION
There're only two themes in the preview extension, use a tailored `loadTheme` to avoid bundling unused themes.

This saves us approximately 30 KB.