### PR TITLE
Improve the way we ensure the caret position

### DIFF
--- a/CoreEditor/src/dom/events/index.ts
+++ b/CoreEditor/src/dom/events/index.ts
@@ -1,3 +1,4 @@
+import { scrollCaretToVisible, scrollToSelection } from '../../modules/selection';
 import isMetaKey from './isMetaKey';
 
 import * as grammarly from '../../modules/grammarly';
@@ -15,6 +16,15 @@ export function startObserving() {
       link.startClickable();
     } else {
       link.stopClickable();
+    }
+
+    // Make sure the main selection is always centered for typewriter mode
+    if (window.config.typewriterMode) {
+      scrollToSelection('center');
+    } else {
+      // We need this because we have different line height for headings,
+      // CodeMirror doesn't by default fix the offset issue.
+      scrollCaretToVisible();
     }
   });
 

--- a/CoreEditor/src/modules/input/index.ts
+++ b/CoreEditor/src/modules/input/index.ts
@@ -1,6 +1,5 @@
 import { EditorView } from '@codemirror/view';
 import { editedState, selectionState } from '../../common/store';
-import { scrollCaretToVisible, scrollToSelection } from '../../modules/selection';
 import { selectedLineColumn } from '../selection/selectedLineColumn';
 import { setShowActiveLineIndicator } from '../../styling/config';
 
@@ -52,17 +51,6 @@ export function observeChanges() {
       // it makes the selection easier to read.
       if (updateActiveLine) {
         setShowActiveLineIndicator(!hasSelection && window.config.showActiveLineIndicator);
-      }
-
-      if (!hasSelection) {
-        // Make sure the main selection is always centered for typewriter mode
-        if (window.config.typewriterMode) {
-          scrollToSelection('center');
-        } else {
-          // We need this because we have different line height for headings,
-          // CodeMirror doesn't by default fix the offset issue.
-          scrollCaretToVisible();
-        }
       }
     }
   });


### PR DESCRIPTION
Move the logic from `update.selectionSet` to `keydown` event, this fixes the issue where the document is jumpy with double clicks.

> It is also to align with other editors, such as VS Code.