### PR TITLE
Remove trailing period when clicking on links

### DIFF
--- a/CoreEditor/src/styling/nodes/link.ts
+++ b/CoreEditor/src/styling/nodes/link.ts
@@ -38,5 +38,13 @@ export function handleMouseUp(event: MouseEvent) {
 function extractLink(target: EventTarget | null) {
   const selector = `.${className}`;
   const element = (target as HTMLElement).closest<HTMLElement>(selector);
-  return element?.innerText;
+  const link = element?.innerText;
+
+  // It's OK to have a trailing period in a valid url,
+  // but generally it's the end of a sentence and we want to remove the period.
+  if (link?.endsWith('.') === true) {
+    return link.slice(0, -1);
+  }
+
+  return link;
 }


### PR DESCRIPTION
We are not going to make the regex super complicated. Instead, simply remove the period from the url.