### PR TITLE
Move shared types to MarkEditCore

### DIFF
--- a/CoreEditor/src/@codegen/config.json
+++ b/CoreEditor/src/@codegen/config.json
@@ -37,7 +37,7 @@
         }
       ],
       "namedTypesTemplatePath": "swift-shared-types.mustache",
-      "namedTypesOutputPath": "../../../MarkEditKit/Sources/Generated/SharedTypes.swift",
+      "namedTypesOutputPath": "../../../MarkEditCore/Sources/EditorSharedTypes.swift",
       "typeNameMap": {
         "CodeGen_Int": "Int"
       }

--- a/CoreEditor/src/@codegen/swift-web-module.mustache
+++ b/CoreEditor/src/@codegen/swift-web-module.mustache
@@ -8,6 +8,7 @@
 //  To make changes, edit template files under /CoreEditor/src/@codegen
 
 import WebKit
+import MarkEditCore
 
 public final class {{moduleName}} {
   private weak var webView: WKWebView?

--- a/MarkEditKit/Sources/Bridge/Web/Generated/WebBridgeConfig.swift
+++ b/MarkEditKit/Sources/Bridge/Web/Generated/WebBridgeConfig.swift
@@ -8,6 +8,7 @@
 //  To make changes, edit template files under /CoreEditor/src/@codegen
 
 import WebKit
+import MarkEditCore
 
 public final class WebBridgeConfig {
   private weak var webView: WKWebView?

--- a/MarkEditKit/Sources/Bridge/Web/Generated/WebBridgeCore.swift
+++ b/MarkEditKit/Sources/Bridge/Web/Generated/WebBridgeCore.swift
@@ -8,6 +8,7 @@
 //  To make changes, edit template files under /CoreEditor/src/@codegen
 
 import WebKit
+import MarkEditCore
 
 public final class WebBridgeCore {
   private weak var webView: WKWebView?

--- a/MarkEditKit/Sources/Bridge/Web/Generated/WebBridgeFormat.swift
+++ b/MarkEditKit/Sources/Bridge/Web/Generated/WebBridgeFormat.swift
@@ -8,6 +8,7 @@
 //  To make changes, edit template files under /CoreEditor/src/@codegen
 
 import WebKit
+import MarkEditCore
 
 public final class WebBridgeFormat {
   private weak var webView: WKWebView?

--- a/MarkEditKit/Sources/Bridge/Web/Generated/WebBridgeGrammarly.swift
+++ b/MarkEditKit/Sources/Bridge/Web/Generated/WebBridgeGrammarly.swift
@@ -8,6 +8,7 @@
 //  To make changes, edit template files under /CoreEditor/src/@codegen
 
 import WebKit
+import MarkEditCore
 
 public final class WebBridgeGrammarly {
   private weak var webView: WKWebView?

--- a/MarkEditKit/Sources/Bridge/Web/Generated/WebBridgeHistory.swift
+++ b/MarkEditKit/Sources/Bridge/Web/Generated/WebBridgeHistory.swift
@@ -8,6 +8,7 @@
 //  To make changes, edit template files under /CoreEditor/src/@codegen
 
 import WebKit
+import MarkEditCore
 
 public final class WebBridgeHistory {
   private weak var webView: WKWebView?

--- a/MarkEditKit/Sources/Bridge/Web/Generated/WebBridgeLineEndings.swift
+++ b/MarkEditKit/Sources/Bridge/Web/Generated/WebBridgeLineEndings.swift
@@ -8,6 +8,7 @@
 //  To make changes, edit template files under /CoreEditor/src/@codegen
 
 import WebKit
+import MarkEditCore
 
 public final class WebBridgeLineEndings {
   private weak var webView: WKWebView?

--- a/MarkEditKit/Sources/Bridge/Web/Generated/WebBridgeSearch.swift
+++ b/MarkEditKit/Sources/Bridge/Web/Generated/WebBridgeSearch.swift
@@ -8,6 +8,7 @@
 //  To make changes, edit template files under /CoreEditor/src/@codegen
 
 import WebKit
+import MarkEditCore
 
 public final class WebBridgeSearch {
   private weak var webView: WKWebView?

--- a/MarkEditKit/Sources/Bridge/Web/Generated/WebBridgeSelection.swift
+++ b/MarkEditKit/Sources/Bridge/Web/Generated/WebBridgeSelection.swift
@@ -8,6 +8,7 @@
 //  To make changes, edit template files under /CoreEditor/src/@codegen
 
 import WebKit
+import MarkEditCore
 
 public final class WebBridgeSelection {
   private weak var webView: WKWebView?

--- a/MarkEditKit/Sources/Bridge/Web/Generated/WebBridgeTableOfContents.swift
+++ b/MarkEditKit/Sources/Bridge/Web/Generated/WebBridgeTableOfContents.swift
@@ -8,6 +8,7 @@
 //  To make changes, edit template files under /CoreEditor/src/@codegen
 
 import WebKit
+import MarkEditCore
 
 public final class WebBridgeTableOfContents {
   private weak var webView: WKWebView?

--- a/MarkEditKit/Sources/Bridge/Web/Generated/WebBridgeTextChecker.swift
+++ b/MarkEditKit/Sources/Bridge/Web/Generated/WebBridgeTextChecker.swift
@@ -8,6 +8,7 @@
 //  To make changes, edit template files under /CoreEditor/src/@codegen
 
 import WebKit
+import MarkEditCore
 
 public final class WebBridgeTextChecker {
   private weak var webView: WKWebView?


### PR DESCRIPTION
We need to add a shared type to `EditorConfig` soon, it should exist in `MarkEditCore` instead of `MarkEditKit`.