### PR TITLE
Tint visible tabs with mask-image

### DIFF
--- a/CoreEditor/src/styling/builder.ts
+++ b/CoreEditor/src/styling/builder.ts
@@ -64,12 +64,16 @@ const sharedStyles: { [selector: string]: StyleSpec } = {
     borderLeft: 'none',
   },
   // Extended
-  '.cm-visibleTab': {
-    backgroundImage: 'url(\'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="200" height="20"><path stroke="%23888" stroke-width="1.2" fill="none" stroke-linecap="round" stroke-linejoin="round" d="M190.5 5l6 5m-6 5l6-5M1 10h195"/></svg>\')',
-    backgroundSize: 'auto 100%',
-    backgroundPosition: 'right 90%',
-    backgroundRepeat: 'no-repeat',
-  },
+  '.cm-visibleTab': (() => {
+    // Chrome right now doesn't support mask-image, prefix them with -webkit- for testing purpose
+    const prefix = /Chrome/.test(navigator.userAgent) ? '-webkit-mask' : 'mask';
+    const attributes = {};
+    attributes[`${prefix}-image`] = 'url(\'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="200" height="20"><path stroke="%23888" stroke-width="1.2" fill="none" stroke-linecap="round" stroke-linejoin="round" d="M190.5 5l6 5m-6 5l6-5M1 10h195"/></svg>\')';
+    attributes[`${prefix}-size`] = 'auto 100%';
+    attributes[`${prefix}-position`] = 'right 90%';
+    attributes[`${prefix}-repeat`] = 'no-repeat';
+    return attributes;
+  })(),
   '.cm-visibleSpace:before': {
     content: 'attr(content)',
     position: 'absolute',
@@ -160,6 +164,9 @@ function buildTheme(colors: EditorColors, scheme?: ColorScheme) {
       backgroundColor: '#960000',
     },
     // Extended
+    '.cm-visibleTab': {
+      backgroundColor: colors.visibleSpace,
+    },
     '.cm-visibleSpace:before': {
       color: colors.visibleSpace,
     },


### PR DESCRIPTION
Both whitespaces and tabs are now tinted with colors provided in themes.