### PR TITLE
Improve visibility of selected lines in focus mode

### DIFF
--- a/CoreEditor/src/config.ts
+++ b/CoreEditor/src/config.ts
@@ -58,6 +58,7 @@ export interface Dynamics {
   gutters?: Compartment;
   invisibles?: Compartment;
   activeLine?: Compartment;
+  selectedLines?: Compartment;
   lineWrapping?: Compartment;
   lineEndings?: Compartment;
   indentUnit?: Compartment;

--- a/CoreEditor/src/extensions.ts
+++ b/CoreEditor/src/extensions.ts
@@ -30,6 +30,7 @@ const theme = new Compartment;
 const gutters = new Compartment;
 const invisibles = new Compartment;
 const activeLine = new Compartment;
+const selectedLines = new Compartment;
 const lineWrapping = new Compartment;
 const lineEndings = new Compartment;
 const indentUnit = new Compartment;
@@ -39,6 +40,7 @@ window.dynamics = {
   gutters,
   invisibles,
   activeLine,
+  selectedLines,
   lineWrapping,
   lineEndings,
   indentUnit,
@@ -99,6 +101,7 @@ export function extensions(options: { lineBreak?: string }) {
     // Styling
     theme.of(loadTheme(window.config.theme)),
     invisibles.of([]),
+    selectedLines.of([]),
     renderExtensions,
     actionExtensions,
 

--- a/CoreEditor/src/styling/config.ts
+++ b/CoreEditor/src/styling/config.ts
@@ -4,6 +4,7 @@ import { Config, InvisiblesBehavior } from '../config';
 import { selectionState, styleSheets } from '../common/store';
 import { gutterExtensions } from './nodes/gutter';
 import { invisiblesExtension } from './nodes/invisible';
+import { selectedLinesDecoration } from './nodes/selection';
 import { calculateFontSize } from './nodes/heading';
 import { shadowableTextColor, updateStyleSheet } from './helper';
 
@@ -141,10 +142,17 @@ export function setInvisiblesBehavior(behavior: InvisiblesBehavior) {
 }
 
 export function setFocusMode(enabled: boolean) {
+  const editor = window.editor as EditorView | null;
+  if (typeof editor?.dispatch === 'function') {
+    editor.dispatch({
+      effects: window.dynamics.selectedLines?.reconfigure(enabled ? selectedLinesDecoration : []),
+    });
+  }
+
   if (styleSheets.focusMode === undefined) {
     const style = document.createElement('style');
     style.textContent = `
-      .cm-line:not(.cm-activeLine), .cm-gutterElement:not(.cm-activeLineGutter) {
+      .cm-line:not(.cm-selectedLineRange), .cm-gutterElement:not(.cm-activeLineGutter) {
         filter: grayscale(1);
         opacity: 0.3;
       }

--- a/CoreEditor/src/styling/nodes/selection.ts
+++ b/CoreEditor/src/styling/nodes/selection.ts
@@ -1,4 +1,6 @@
 import { Decoration, DecorationSet, ViewPlugin, ViewUpdate } from '@codemirror/view';
+import { RangeSetBuilder } from '@codemirror/state';
+import { linesWithRange } from '../../modules/selection';
 
 /**
  * CodeMirror only decorates the active line with a cm-activeLine class,
@@ -18,8 +20,42 @@ export const selectedTextDecoration = ViewPlugin.fromClass(class {
     }
 
     const ranges = update.state.selection.ranges.filter(range => range.to !== range.from);
+    const markDeco = Decoration.mark({ class: 'cm-selectedTextRange' });
     this.decorations = Decoration.set(ranges.map(range => {
-      return Decoration.mark({ class: 'cm-selectedTextRange' }).range(range.from, range.to);
+      return markDeco.range(range.from, range.to);
     }));
+  }
+}, { decorations: instance => instance.decorations });
+
+/**
+ * CodeMirror only decorates the active line with a cm-activeLine class,
+ * we use this extension to decorate all selected lines, a line can be partially selected.
+ *
+ * This is useful for implementing features like focus mode.
+ */
+export const selectedLinesDecoration = ViewPlugin.fromClass(class {
+  decorations: DecorationSet;
+  constructor() {
+    this.updateDecos();
+  }
+
+  update(update: ViewUpdate) {
+    if (update.selectionSet) {
+      this.updateDecos();
+    }
+  }
+
+  updateDecos() {
+    const builder = new RangeSetBuilder<Decoration>();
+    const ranges = window.editor.state.selection.ranges;
+    const lineDeco = Decoration.line({ class: 'cm-selectedLineRange' });
+
+    for (const { from, to } of ranges) {
+      for (const line of linesWithRange(from, to)) {
+        builder.add(line.from, line.from, lineDeco);
+      }
+    }
+
+    this.decorations = builder.finish();
   }
 }, { decorations: instance => instance.decorations });


### PR DESCRIPTION
We used to rely on CodeMirror's `highlightActiveLine` extension for focus mode, which is not comprehensive.

Ideally, selected lines should not be faded out, not only the active line.

This PR uses a similar technique we used in https://github.com/MarkEdit-app/MarkEdit/pull/53 and reverts https://github.com/MarkEdit-app/MarkEdit/pull/30.