### PR TITLE
Reduce StateField.define for unnecessary situations

### DIFF
--- a/CoreEditor/src/styling/matchers/stateful.ts
+++ b/CoreEditor/src/styling/matchers/stateful.ts
@@ -25,8 +25,7 @@ export function startEffect(compartment: Compartment, ranges: RangeSet<Decoratio
  */
 export function stopEffect(compartments: Compartment[]) {
   for (const compartment of compartments) {
-    const extension = StateField.define({ create() { /* no-op */ }, update() { /* no-op */ } });
-    const effects = compartment.reconfigure(extension);
+    const effects = compartment.reconfigure([]);
     window.editor.dispatch({ effects });
   }
 }


### PR DESCRIPTION
It was really unnecessary to use a dummy StateField.