### PR TITLE
Improve autocorrect for whitespace rendering

### DIFF
--- a/CoreEditor/src/modules/input/index.ts
+++ b/CoreEditor/src/modules/input/index.ts
@@ -4,6 +4,7 @@ import { editedState, selectionState } from '../../common/store';
 import { selectedLineColumn } from '../selection/selectedLineColumn';
 import { setInvisiblesBehavior } from '../config';
 import { setShowActiveLineIndicator } from '../../styling/config';
+import { renderWhitespaceBeforeCaret } from '../../styling/nodes/invisible';
 
 import selectedRange from '../selection/selectedRanges';
 import wrapBlock from './wrapBlock';
@@ -60,6 +61,9 @@ export function observeChanges() {
         // it makes the selection easier to read.
         setShowActiveLineIndicator(!hasSelection && window.config.showActiveLineIndicator);
       }
+
+      // Render the special invisible before the main caret
+      renderWhitespaceBeforeCaret();
     }
   });
 }

--- a/CoreEditor/src/styling/nodes/invisible.ts
+++ b/CoreEditor/src/styling/nodes/invisible.ts
@@ -1,4 +1,5 @@
 import { Decoration, highlightTrailingWhitespace } from '@codemirror/view';
+import { Compartment } from '@codemirror/state';
 import { syntaxTree } from '@codemirror/language';
 import { NodeType } from '@lezer/common';
 import { InvisiblesBehavior } from '../../config';
@@ -7,6 +8,7 @@ import { createMarkDeco } from '../matchers/regex';
 import { createDecoPlugin } from '../helper';
 import { selectedTextDecoration } from './selection';
 import { frontMatterRange } from '../../modules/frontMatter';
+import { startEffect, stopEffect } from '../matchers/stateful';
 
 // Originally learned from: https://github.com/ChromeDevTools/devtools-frontend/blob/main/front_end/ui/components/text_editor/config.ts
 //
@@ -17,10 +19,54 @@ import { frontMatterRange } from '../../modules/frontMatter';
 // we need to figure out proper font size and set it to the pseudo class.
 const renderInvisibles = createDecoPlugin(() => {
   return createMarkDeco(/\t| +/g, (match, pos) => {
+    // If it's before the main caret and always show invisibles, we simply skip.
+    //
+    // The reason behind this is that <span> elements created for invisibles can break autocorrect features,
+    // see `renderWhitespaceBeforeCaret` regarding how we draw this special whitespace.
     const invisible = match[0];
+    if (alwaysRenderInvisibles() && invisible === ' ' && pos === window.editor.state.selection.main.anchor - 1) {
+      return null;
+    }
+
     return getOrCreateDeco(invisible, pos);
   });
 });
+
+// This function renders the space before the main caret "lazily".
+//
+// The reason we need this special rendering logic is that <span> elements can mess up autocorrect features,
+// with some delay can make sure autocorrect work.
+export function renderWhitespaceBeforeCaret() {
+  if (!alwaysRenderInvisibles()) {
+    return;
+  }
+
+  if (storage.lazyCompartment !== undefined) {
+    stopEffect([storage.lazyCompartment]);
+    storage.lazyCompartment = undefined;
+  }
+
+  if (storage.lazyRenderer !== undefined) {
+    clearTimeout(storage.lazyRenderer);
+    storage.lazyRenderer = undefined;
+  }
+
+  storage.lazyRenderer = setTimeout(() => {
+    const editor = window.editor;
+    const doc = editor.state.doc;
+
+    const to = editor.state.selection.main.anchor;
+    const from = to - 1;
+    const spaces = doc.sliceString(from - 1, to + 1);
+
+    // Example valid patterns: " (caret)", "x (caret)", "x (caret)y".
+    if (from >= 0 && (/^[^ ]? $/.test(spaces) || /^[^ ] [^ ]$/.test(spaces))) {
+      const deco = getOrCreateDeco(' ', from);
+      storage.lazyCompartment = new Compartment;
+      startEffect(storage.lazyCompartment, Decoration.set(deco.range(from, to)));
+    }
+  }, 50);
+}
 
 export function invisiblesExtension(behavior: InvisiblesBehavior, hasSelection: boolean) {
   if (behavior === InvisiblesBehavior.always) {
@@ -36,6 +82,10 @@ export function invisiblesExtension(behavior: InvisiblesBehavior, hasSelection: 
   }
 
   return [];
+}
+
+function alwaysRenderInvisibles() {
+  return window.config.invisiblesBehavior === InvisiblesBehavior.always;
 }
 
 /**
@@ -54,7 +104,7 @@ function getOrCreateDeco(invisible: string, pos: number) {
   })();
 
   const key = invisible + fontSize;
-  const cachedDeco = cachedDecos.get(key);
+  const cachedDeco = storage.cachedDecos.get(key);
 
   // Great, exactly the same deco was created before
   if (cachedDeco !== undefined) {
@@ -78,7 +128,7 @@ function getOrCreateDeco(invisible: string, pos: number) {
     },
   });
 
-  cachedDecos.set(key, newDeco);
+  storage.cachedDecos.set(key, newDeco);
   return newDeco;
 }
 
@@ -88,4 +138,12 @@ function headingLevel(type: NodeType) {
   return match ? +match[1] : 0;
 }
 
-const cachedDecos = new Map<string, Decoration>();
+const storage: {
+  cachedDecos: Map<string, Decoration>;
+  lazyRenderer: ReturnType<typeof setTimeout> | undefined;
+  lazyCompartment: Compartment | undefined;
+} = {
+  cachedDecos: new Map<string, Decoration>(),
+  lazyRenderer: undefined,
+  lazyCompartment: undefined,
+};


### PR DESCRIPTION
This is the craziest trick so far. To solve issues mentioned in https://github.com/MarkEdit-app/MarkEdit/issues/37#issuecomment-1435695611, introduces `renderWhitespaceBeforeCaret` to lazily render the space before the main caret.

With this PR, autocorrect works much better when invisible rendering is set to `always`.