### PR TITLE
Fix fails to paste copied URLs

### DIFF
--- a/MarkEditMac/Base.lproj/Main.storyboard
+++ b/MarkEditMac/Base.lproj/Main.storyboard
@@ -273,7 +273,7 @@
                                         </menuItem>
                                         <menuItem title="Paste" keyEquivalent="v" id="gVA-U4-sdL">
                                             <connections>
-                                                <action selector="paste:" target="Ady-hI-5gd" id="UvS-8e-Qdg"/>
+                                                <action selector="performPaste:" target="Ady-hI-5gd" id="QG8-DJ-mZi"/>
                                             </connections>
                                         </menuItem>
                                         <menuItem title="Delete" id="pa3-QI-u2k">

--- a/MarkEditMac/Modules/Sources/AppKitExtensions/Foundation/NSPasteboard+Extension.swift
+++ b/MarkEditMac/Modules/Sources/AppKitExtensions/Foundation/NSPasteboard+Extension.swift
@@ -7,6 +7,10 @@
 import AppKit
 
 public extension NSPasteboard {
+  var canPaste: Bool {
+    pasteboardItems?.isEmpty == false
+  }
+
   var string: String? {
     string(forType: .string)
   }
@@ -24,6 +28,14 @@ public extension NSPasteboard {
 
     if let string {
       setString(string, forType: .string)
+    }
+  }
+
+  func sanitize() {
+    // Handle the case where a link is only copied to "public.url",
+    // for example, copying the link generated for iCloud Collaborate.
+    if string?.isEmpty ?? true, let url = string(forType: .URL), !url.isEmpty {
+      overwrite(string: url)
     }
   }
 }

--- a/MarkEditMac/Sources/Editor/Controllers/EditorViewController+Menu.swift
+++ b/MarkEditMac/Sources/Editor/Controllers/EditorViewController+Menu.swift
@@ -34,6 +34,10 @@ extension EditorViewController: NSMenuItemValidation {
       return document?.fileURL != nil
     }
 
+    if menuItem.action == #selector(performPaste(_:)) {
+      return NSPasteboard.general.canPaste
+    }
+
     return true
   }
 }
@@ -221,6 +225,11 @@ private extension EditorViewController {
 
   @IBAction func redo(_ sender: Any?) {
     bridge.history.redo()
+  }
+
+  @IBAction func performPaste(_ sender: Any?) {
+    NSPasteboard.general.sanitize()
+    NSApp.sendAction(#selector(NSText.paste(_:)), to: nil, from: nil)
   }
 
   @IBAction func gotoLine(_ sender: Any?) {


### PR DESCRIPTION
This is really an edge case that most apps cannot handle correctly, sometimes URLs are copied to `public.url` and normal string types are empty.

To improve this, we sanitize the pasteboard before pasting.