### PR TITLE
Improve NSPasteboard.url

### DIFF
--- a/MarkEditMac/Modules/Sources/AppKitExtensions/Foundation/NSPasteboard+Extension.swift
+++ b/MarkEditMac/Modules/Sources/AppKitExtensions/Foundation/NSPasteboard+Extension.swift
@@ -17,7 +17,7 @@ public extension NSPasteboard {
 
   var url: String? {
     guard let string else {
-      return nil
+      return string(forType: .URL)
     }
 
     return NSDataDetector.extractURL(from: string)


### PR DESCRIPTION
Fallback to `string(forType: .URL)` when necessary.