### PR TITLE
Greedy table of contents parsing for small documents

### DIFF
--- a/CoreEditor/src/modules/toc/index.ts
+++ b/CoreEditor/src/modules/toc/index.ts
@@ -17,9 +17,9 @@ export function getTableOfContents() {
       return ensureSyntaxTree(state, length) ?? syntaxTree(state);
     }
 
-  // Note that, it's not going to iterate the entire tree (might not have been parsed).
-  //
-  // This is by design because of potential performance issues.
+    // Note that, it's not going to iterate the entire tree (might not have been parsed).
+    //
+    // This is by design because of potential performance issues.
     return syntaxTree(state);
   })();
 


### PR DESCRIPTION
For documents that are smaller than 100 KB, use `ensureSyntaxTree` instead of `syntaxTree`.