### PR TITLE
More consistent comment style

### DIFF
--- a/MarkEditCore/Sources/Extensions/Data+Extension.swift
+++ b/MarkEditCore/Sources/Extensions/Data+Extension.swift
@@ -7,9 +7,9 @@
 import Foundation
 
 public extension Data {
-  /// Handle text encoding in Cocoa apps: https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/Strings/introStrings.html
+  /// Handle text encoding in Cocoa apps: https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/Strings/introStrings.html.
   ///
-  /// Ideally, the encoding for Markdown should always be utf-8 as described in: https://daringfireball.net/linked/2011/08/05/markdown-uti
+  /// Ideally, the encoding for Markdown should always be utf-8 as described in: https://daringfireball.net/linked/2011/08/05/markdown-uti.
   func toString(encoding: String.Encoding = .utf8) -> String? {
     // Perfect, successfully decoded it with the preferred encoding
     if let decoded = String(data: self, encoding: encoding) {

--- a/MarkEditCore/Sources/Extensions/EditorConfig+Extension.swift
+++ b/MarkEditCore/Sources/Extensions/EditorConfig+Extension.swift
@@ -13,7 +13,7 @@ public extension EditorConfig {
 }
 
 extension EditorConfig {
-  /// index.html built by CoreEditor
+  /// index.html built by CoreEditor.
   private var indexHtml: String? {
     guard let path = Bundle.main.url(forResource: "index", withExtension: "html") else {
       fatalError("Missing index.html to set up the editor")

--- a/MarkEditCore/Sources/Extensions/String+Extension.swift
+++ b/MarkEditCore/Sources/Extensions/String+Extension.swift
@@ -7,12 +7,12 @@
 import Foundation
 
 public extension String {
-  /// Overload of the String.Encoding version
+  /// Overload of the String.Encoding version.
   init?(data: Data, encoding: CFStringEncodings) {
     self.init(data: data, encoding: String.Encoding(from: encoding))
   }
 
-  /// Overload of the String.Encoding version
+  /// Overload of the String.Encoding version.
   func data(using encoding: CFStringEncodings, allowLossyConversion: Bool = false) -> Data? {
     data(using: String.Encoding(from: encoding), allowLossyConversion: allowLossyConversion)
   }

--- a/MarkEditKit/Sources/Bridge/Native/NativeModules.swift
+++ b/MarkEditKit/Sources/Bridge/Native/NativeModules.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-/// Native method that will be invoked by JavaScript
+/// Native method that will be invoked by JavaScript.
 public typealias NativeMethod = (_ parameters: Data) async -> Result<Encodable?, Error>?
 
 public protocol NativeBridge: AnyObject {

--- a/MarkEditKit/Sources/EditorMessageHandler.swift
+++ b/MarkEditKit/Sources/EditorMessageHandler.swift
@@ -61,7 +61,7 @@ public final class EditorMessageHandler: NSObject, WKScriptMessageHandler {
 // MARK: - Private
 
 private extension EditorMessageHandler {
-  /// Reply to a message sent by JavaScript
+  /// Reply to a message sent by JavaScript.
   func reply(id: String, result: Result<Encodable?, Error>) {
     guard let webView = webViewProvider() else {
       Logger.log(.error, "Missing WebView to proceed")
@@ -96,9 +96,9 @@ private extension EditorMessageHandler {
   }
 }
 
-/// Encodable wrapper for generics
+/// Encodable wrapper for generics.
 ///
-/// https://www.dabby.dev/article/2019-04-25-any-encodable
+/// https://www.dabby.dev/article/2019-04-25-any-encodable.
 private struct AnyEncodable: Encodable {
   let value: Encodable
 

--- a/MarkEditKit/Sources/EditorTextEncoding.swift
+++ b/MarkEditKit/Sources/EditorTextEncoding.swift
@@ -6,10 +6,10 @@
 
 import Foundation
 
-/// https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/Strings/Articles/readingFiles.html#//apple_ref/doc/uid/TP40003459-SW4
+/// https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/Strings/Articles/readingFiles.html#//apple_ref/doc/uid/TP40003459-SW4.
 ///
 /// We *can*, but don't want to, include all supported encodings, which makes the UI super complicated,
-/// Markdown prefers utf-8 as mentioned here: https://daringfireball.net/linked/2011/08/05/markdown-uti
+/// Markdown prefers utf-8 as mentioned here: https://daringfireball.net/linked/2011/08/05/markdown-uti.
 public enum EditorTextEncoding: CaseIterable, CustomStringConvertible, Codable {
   // Derived from String.Encoding
   case ascii
@@ -88,7 +88,7 @@ public enum EditorTextEncoding: CaseIterable, CustomStringConvertible, Codable {
 }
 
 public extension EditorTextEncoding {
-  /// In menus, grouping cases with a separator
+  /// In menus, grouping cases with a separator.
   static var groupingCases: Set<Self> {
     Set([.nonLossyASCII, .utf16LittleEndian, .windowsLatin1, .big5, .shiftJIS])
   }

--- a/MarkEditMac/Modules/Sources/AppKitExtensions/UI/NSMenu+Extension.swift
+++ b/MarkEditMac/Modules/Sources/AppKitExtensions/UI/NSMenu+Extension.swift
@@ -27,7 +27,7 @@ public extension NSMenu {
     return item
   }
 
-  /// Force an update, the .update() method doesn't work reliably
+  /// Force an update, the .update() method doesn't work reliably.
   func reloadItems() {
     let item = NSMenuItem.separator()
     addItem(item)

--- a/MarkEditMac/Modules/Sources/AppKitExtensions/UI/NSView+Extension.swift
+++ b/MarkEditMac/Modules/Sources/AppKitExtensions/UI/NSView+Extension.swift
@@ -57,12 +57,12 @@ public extension NSView {
     }
   }
 
-  /// Check if the view itself or its children is the first responder in a window
+  /// Check if the view itself or its children is the first responder in a window.
   func isFirstResponder(in window: NSWindow?) -> Bool {
     (window?.firstResponder as? NSView)?.belongs(to: self) ?? false
   }
 
-  /// Check if the view is a child of another view, or is another view
+  /// Check if the view is a child of another view, or is another view.
   func belongs(to view: NSView) -> Bool {
     var node: NSView? = self
     while node != nil {
@@ -79,7 +79,7 @@ public extension NSView {
     animated ? animator() : self
   }
 
-  /// Enumerate all children, recursively, self first
+  /// Enumerate all children, recursively, self first.
   func enumerateChildren<T: NSView>(where: ((T) -> Bool)? = nil, handler: (T) -> Void) {
     if let view = self as? T, `where`?(view) ?? true {
       handler(view)

--- a/MarkEditMac/Modules/Sources/AppKitExtensions/UI/NSWindow+Extension.swift
+++ b/MarkEditMac/Modules/Sources/AppKitExtensions/UI/NSWindow+Extension.swift
@@ -25,14 +25,14 @@ public extension NSWindow {
     return result
   }
 
-  /// Change the frame size, treat the top-left corner as the anchor point
+  /// Change the frame size, treat the top-left corner as the anchor point.
   func setFrameSize(_ target: CGSize, display flag: Bool = false, animated: Bool = false) {
     let size = frameRect(forContentRect: CGRect(origin: .zero, size: target)).size
     let frame = CGRect(origin: frame.origin, size: size).offsetBy(dx: 0, dy: frame.height - size.height)
     setFrame(frame, display: flag, animate: animated)
   }
 
-  /// Move to the center of the screen, the built-in .center() method doesn't work reliably
+  /// Move to the center of the screen, the built-in .center() method doesn't work reliably.
   func moveToCenter() {
     guard let visibleSize = screen?.visibleFrame.size, let fullSize = screen?.frame.size else {
       return
@@ -44,7 +44,7 @@ public extension NSWindow {
     ))
   }
 
-  /// Get the cascade rect based on a rect
+  /// Get the cascade rect based on a rect.
   func cascadeRect(from rect: CGRect) -> CGRect {
     let origin = cascadeTopLeft(from: CGPoint(
       x: rect.origin.x,

--- a/MarkEditMac/Modules/Sources/Previewer/Previewer.swift
+++ b/MarkEditMac/Modules/Sources/Previewer/Previewer.swift
@@ -76,7 +76,7 @@ public final class Previewer: NSViewController {
     return try? Data(contentsOf: path).toString()
   }
 
-  /// Observe body size change and update content size accordingly
+  /// Observe body size change and update content size accordingly.
   private var resizeObserver: WKUserScript {
     let source = """
     const observer = new ResizeObserver(entries => {

--- a/MarkEditMac/Sources/Editor/Controllers/EditorViewController+Menu.swift
+++ b/MarkEditMac/Sources/Editor/Controllers/EditorViewController+Menu.swift
@@ -21,7 +21,7 @@ extension EditorViewController: NSMenuDelegate {
 // MARK: - NSMenuItemValidation
 
 extension EditorViewController: NSMenuItemValidation {
-  /// Actions that require the existence of a file
+  /// Actions that require the existence of a file.
   private static let fileActions = [
     #selector(copyFilePath(_:)),
     #selector(copyFolderPath(_:)),

--- a/MarkEditMac/Sources/Editor/Models/EditorReusePool.swift
+++ b/MarkEditMac/Sources/Editor/Models/EditorReusePool.swift
@@ -33,7 +33,7 @@ final class EditorReusePool {
     return EditorViewController()
   }
 
-  /// All editors, whether with or without a visible window
+  /// All editors, whether with or without a visible window.
   func viewControllers() -> [EditorViewController] {
     controllerPool + {
       let windows = NSApplication.shared.windows.compactMap { $0 as? EditorWindow }

--- a/MarkEditMac/Sources/Editor/Models/EditorToolbarItems.swift
+++ b/MarkEditMac/Sources/Editor/Models/EditorToolbarItems.swift
@@ -41,7 +41,7 @@ extension NSToolbarItem {
     return item
   }
 
-  /// Used in toolTip as a hint, values should match mainMenu
+  /// Used in toolTip as a hint, values should match mainMenu.
   var shortcutHint: String? {
     switch itemIdentifier {
     case .toggleBold: return "⌘ B"

--- a/MarkEditMac/Sources/Main/AppTheme.swift
+++ b/MarkEditMac/Sources/Main/AppTheme.swift
@@ -20,12 +20,12 @@ struct AppTheme {
     allCases.first { $0.editorTheme == name } ?? GitHubLight
   }
 
-  /// Get a "resolved" appearance name based on the current effective appearance
+  /// Get a "resolved" appearance name based on the current effective appearance.
   var resolvedAppearance: NSAppearance? {
     NSAppearance(named: NSApp.effectiveAppearance.resolvedName(isDarkMode: isDark))
   }
 
-  /// Trigger theme update for all editors
+  /// Trigger theme update for all editors.
   func updateAppearance() {
     EditorReusePool.shared.viewControllers().forEach {
       $0.setTheme(self)

--- a/MarkEditMac/Sources/Panels/Find/EditorFindPanel+Menu.swift
+++ b/MarkEditMac/Sources/Panels/Find/EditorFindPanel+Menu.swift
@@ -8,7 +8,7 @@
 import AppKit
 
 extension EditorFindPanel {
-  /// Reset the search menu, generally after search mode changed
+  /// Reset the search menu, generally after search mode changed.
   func resetMenu() {
     let menu = NSMenu()
     menu.addItem(withTitle: Localized.Search.find, action: #selector(enableFindMode(_:))).setOn(mode != .replace)

--- a/MarkEditMac/Sources/Panels/Find/EditorFindPanel.swift
+++ b/MarkEditMac/Sources/Panels/Find/EditorFindPanel.swift
@@ -9,11 +9,11 @@ import AppKit
 import AppKitControls
 
 @frozen enum EditorFindMode {
-  /// Find panel is not visible
+  /// Find panel is not visible.
   case hidden
-  /// Find panel is visible, shows only find
+  /// Find panel is visible, shows only find.
   case find
-  /// Find panel is visible, shows both find and replace
+  /// Find panel is visible, shows both find and replace.
   case replace
 }
 


### PR DESCRIPTION
For documentation comments, make sure end with a `.` (period).