### PR TITLE
Improve case insensitive search

### DIFF
--- a/MarkEditCore/Sources/Extensions/String+Extension.swift
+++ b/MarkEditCore/Sources/Extensions/String+Extension.swift
@@ -20,6 +20,14 @@ public extension String {
   func toData(encoding: String.Encoding = .utf8) -> Data? {
     data(using: encoding)
   }
+
+  func equalsIgnoreCase(_ another: String) -> Bool {
+    caseInsensitiveCompare(another) == .orderedSame
+  }
+
+  func hasPrefixIgnoreCase(_ prefix: String) -> Bool {
+    range(of: prefix, options: [.anchored, .caseInsensitive]) != nil
+  }
 }
 
 extension String.Encoding {

--- a/MarkEditKit/Sources/Bridge/Native/Modules/EditorModuleCompletion.swift
+++ b/MarkEditKit/Sources/Bridge/Native/Modules/EditorModuleCompletion.swift
@@ -57,7 +57,7 @@ public final class EditorModuleCompletion: NativeModuleCompletion {
       anchor: anchor,
       partialRange: NSRange(location: from, length: to - from),
       tokenizedWords: (cachedTokens + tokens(in: anchor.text)).filter {
-        $0.range(of: prefix, options: [.anchored, .caseInsensitive]) != nil
+        $0.hasPrefixIgnoreCase(prefix)
       }
     )
   }

--- a/MarkEditMac/Sources/Editor/Controllers/EditorViewController+Completion.swift
+++ b/MarkEditMac/Sources/Editor/Controllers/EditorViewController+Completion.swift
@@ -27,7 +27,7 @@ extension EditorViewController {
 
     if AppPreferences.Assistant.wordsInDocument {
       // Remove tokens if they "cannot be completed", usually means they are not a word
-      let isWord = completions.contains { $0.caseInsensitiveCompare(prefix) == .orderedSame }
+      let isWord = completions.contains { $0.equalsIgnoreCase(prefix) }
       completions.append(contentsOf: tokenizedWords.filter { isWord || $0 != prefix })
     }
 


### PR DESCRIPTION
Get rid of `lowercased()` conversion and be more tolerant about text cases for words in document.