### PR TITLE
Make completion panel brighter in dark mode

### DIFF
--- a/MarkEditMac/Modules/Sources/TextCompletion/Internal/TextCompletionPanel.swift
+++ b/MarkEditMac/Modules/Sources/TextCompletion/Internal/TextCompletionPanel.swift
@@ -85,6 +85,7 @@ private final class ContentView: NSView {
 
     let effectView = NSVisualEffectView()
     effectView.material = .popover
+    effectView.state = .active // Looks less dimmed in non-key windows
     effectView.translatesAutoresizingMaskIntoConstraints = false
     addSubview(effectView)
 

--- a/MarkEditMac/Modules/Sources/TextCompletion/TextCompletionContext.swift
+++ b/MarkEditMac/Modules/Sources/TextCompletion/TextCompletionContext.swift
@@ -15,21 +15,21 @@ public protocol TextCompletionPanelProtocol {}
  Manages the state of word completions.
  */
 public final class TextCompletionContext {
-  public var isPanelVisible = false {
-    didSet {
-      if !isPanelVisible {
-        panel.orderOut(nil)
-        wasFlipped = false
-      }
-    }
-  }
-
   public var appearance: NSAppearance? {
     get {
       panel.appearance
     }
     set {
       panel.appearance = newValue
+    }
+  }
+
+  public var isPanelVisible = false {
+    didSet {
+      if !isPanelVisible {
+        panel.orderOut(nil)
+        wasFlipped = false
+      }
     }
   }
 


### PR DESCRIPTION
Unlike Xcode, with `state = .active`, dark mode looks more brighter.