### PR TITLE
Enable developerExtrasEnabled for release builds

### DIFF
--- a/MarkEditKit/Sources/Extensions/WKWebViewConfiguration+Extension.swift
+++ b/MarkEditKit/Sources/Extensions/WKWebViewConfiguration+Extension.swift
@@ -17,14 +17,12 @@ public extension WKWebViewConfiguration {
       Logger.assertFail("Failed to overwrite drawsBackground in WKWebViewConfiguration")
     }
 
-  #if DEBUG
     // https://github.com/WebKit/WebKit/blob/main/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm
     if config.preferences.responds(to: sel_getUid("_developerExtrasEnabled")) {
       config.preferences.setValue(true, forKey: "developerExtrasEnabled")
     } else {
       Logger.assertFail("Failed to overwrite developerExtrasEnabled in WKPreferences")
     }
-  #endif
 
     return config
   }


### PR DESCRIPTION
We initially made this for debugging purpose, but since we are making more features for extensibility, it's better we expose this to end users.