### PR TITLE
Normalize paddings for preview extension

### DIFF
--- a/CoreEditor/src/@light/index.html
+++ b/CoreEditor/src/@light/index.html
@@ -9,5 +9,11 @@
 <body>
   <div id="editor"></div>
   <script type=module src="./index.ts"></script>
+  <style>
+    .cm-content {
+      padding-top: 4px !important;
+      padding-bottom: 4px !important;
+    }
+  </style>
 </body>
 </html>


### PR DESCRIPTION
We don't need extra bottom insets in preview extension.