### PR TITLE
Move WebKit replies to native

### DIFF
--- a/CoreEditor/index.ts
+++ b/CoreEditor/index.ts
@@ -14,7 +14,7 @@ import { WebModuleTableOfContentsImpl } from './src/bridge/web/toc';
 import { WebModuleGrammarlyImpl } from './src/bridge/web/grammarly';
 
 import { pseudoDocument } from './src/@test/mock';
-import { createNativeModule, handleNativeReply } from './src/bridge/nativeModule';
+import { createNativeModule } from './src/bridge/nativeModule';
 import { NativeModuleCore } from './src/bridge/native/core';
 import { NativeModuleCompletion } from './src/bridge/native/completion';
 import { NativeModulePreview } from './src/bridge/native/preview';
@@ -69,7 +69,6 @@ window.nativeModules = {
 
 window.onload = () => {
   window.config = config;
-  window.handleNativeReply = handleNativeReply;
   window.nativeModules.core.notifyWindowDidLoad();
 
   // On Prod, text is reset by the native code

--- a/CoreEditor/package.json
+++ b/CoreEditor/package.json
@@ -22,14 +22,12 @@
     "@codemirror/view": "^6.0.0",
     "@grammarly/editor-sdk": "^2.0.0",
     "@lezer/common": "^1.0.0",
-    "js-yaml": "^4.1.0",
-    "uuid": "^9.0.0"
+    "js-yaml": "^4.1.0"
   },
   "devDependencies": {
     "@types/eslint": "^8.4.10",
     "@types/jest": "^29.4.0",
     "@types/js-yaml": "^4.0.0",
-    "@types/uuid": "^9.0.0",
     "@typescript-eslint/eslint-plugin": "^5.50.0",
     "@typescript-eslint/parser": "^5.50.0",
     "eslint": "^8.33.0",

--- a/CoreEditor/src/@types/global.d.ts
+++ b/CoreEditor/src/@types/global.d.ts
@@ -1,7 +1,6 @@
 import { EditorView } from '@codemirror/view';
 import { Config, Dynamics } from '../config';
 import { WebModule } from '../bridge/webModule';
-import { NativeReply } from '../bridge/nativeModule';
 import { NativeModuleCore } from '../bridge/native/core';
 import { NativeModuleCompletion } from '../bridge/native/completion';
 import { NativeModulePreview } from '../bridge/native/preview';
@@ -15,7 +14,7 @@ interface WebKit {
   messageHandlers?: {
     bridge?: {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      postMessage: (object: any) => void;
+      postMessage: (object: any) => Promise<any>;
     };
   };
 }
@@ -33,7 +32,6 @@ declare global {
       preview: NativeModulePreview;
       tokenizer: NativeModuleTokenizer;
     };
-    handleNativeReply: (reply: NativeReply) => void;
   }
 
   interface ImportMetaEnv {

--- a/CoreEditor/yarn.lock
+++ b/CoreEditor/yarn.lock
@@ -1225,11 +1225,6 @@
   resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.2.tgz#6286b4c7228d58ab7866d19716f3696e03a09397"
   integrity sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==
 
-"@types/uuid@^9.0.0":
-  version "9.0.1"
-  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-9.0.1.tgz#98586dc36aee8dacc98cc396dbca8d0429647aa6"
-  integrity sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA==
-
 "@types/yargs-parser@*":
   version "21.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.0.tgz#0c60e537fa790f5f9472ed2776c2b71ec117351b"
@@ -3624,11 +3619,6 @@ url-parse@^1.5.3:
   dependencies:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
-
-uuid@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
-  integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
 
 v8-to-istanbul@^9.0.1:
   version "9.1.0"

--- a/MarkEditMac/Sources/Editor/Controllers/EditorViewController.swift
+++ b/MarkEditMac/Sources/Editor/Controllers/EditorViewController.swift
@@ -77,7 +77,7 @@ final class EditorViewController: NSViewController {
     }
 
     let controller = WKUserContentController()
-    controller.add(handler, name: "bridge")
+    controller.addScriptMessageHandler(handler, contentWorld: .page, name: "bridge")
 
     let config: WKWebViewConfiguration = .newConfig()
     config.processPool = EditorReusePool.shared.processPool


### PR DESCRIPTION
With [WKScriptMessageHandlerWithReply](https://developer.apple.com/documentation/webkit/wkscriptmessagehandlerwithreply) on macOS 11 and above, we can get rid of the homemade version.