### PR TITLE
Fix toc navigation regression on macOS 13.3

### DIFF
--- a/CoreEditor/src/extensions.ts
+++ b/CoreEditor/src/extensions.ts
@@ -25,6 +25,7 @@ import { gutterExtensions } from './styling/nodes/gutter';
 import { localizePhrases } from './modules/localization';
 import { indentationKeymap } from './modules/indentation';
 import { wordTokenizer, observeChanges, interceptInputs } from './modules/input';
+import { tocKeymap } from './modules/toc';
 
 const theme = new Compartment;
 const gutters = new Compartment;
@@ -89,6 +90,7 @@ export function extensions(options: { lineBreak?: string }) {
       // By default CodeMirror disables tab (character) insertion (https://codemirror.net/examples/tab/),
       // however, MarkEdit runs on a WebView instead of browsers, we do want to bind the tab key.
       ...indentationKeymap,
+      ...tocKeymap,
     ]),
 
     // Markdown

--- a/CoreEditor/src/modules/toc/index.ts
+++ b/CoreEditor/src/modules/toc/index.ts
@@ -1,9 +1,30 @@
+import { KeyBinding } from '@codemirror/view';
 import { EditorSelection } from '@codemirror/state';
 import { ensureSyntaxTree, syntaxTree } from '@codemirror/language';
 import { HeadingInfo } from './types';
 import { frontMatterRange } from '../frontMatter';
 import { scrollToSelection } from '../selection';
 import selectWithRanges from '../selection/selectWithRanges';
+
+// Override the system default behavior, it was not necessary until macOS 13.3
+export const tocKeymap: KeyBinding[] = [
+  {
+    key: 'Alt-Mod-ArrowUp',
+    preventDefault: true,
+    run: () => {
+      selectPreviousSection();
+      return true;
+    },
+  },
+  {
+    key: 'Alt-Mod-ArrowDown',
+    preventDefault: true,
+    run: () => {
+      selectNextSection();
+      return true;
+    },
+  },
+];
 
 export function getTableOfContents() {
   const editor = window.editor;


### PR DESCRIPTION
Someone in Cupertino made such an annoying change.