### PR TITLE
Leverage PreActions to kill DEBUG process

### DIFF
--- a/MarkEdit.xcodeproj/xcshareddata/xcschemes/MarkEditMac (screenshots).xcscheme
+++ b/MarkEdit.xcodeproj/xcshareddata/xcschemes/MarkEditMac (screenshots).xcscheme
@@ -51,6 +51,15 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Kill Debug Process"
+               scriptText = "id=$(pgrep MarkEdit || true)&#10;path=$(which `ps -o comm= -p $id`)&#10;&#10;if [[ $path == *&quot;/Build/Products/Debug/&quot;* ]]; then&#10;  kill $id&#10;fi&#10;">
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference

--- a/MarkEdit.xcodeproj/xcshareddata/xcschemes/MarkEditMac (zh-Hans).xcscheme
+++ b/MarkEdit.xcodeproj/xcshareddata/xcschemes/MarkEditMac (zh-Hans).xcscheme
@@ -52,6 +52,15 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Kill Debug Process"
+               scriptText = "id=$(pgrep MarkEdit || true)&#10;path=$(which `ps -o comm= -p $id`)&#10;&#10;if [[ $path == *&quot;/Build/Products/Debug/&quot;* ]]; then&#10;  kill $id&#10;fi&#10;">
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference

--- a/MarkEdit.xcodeproj/xcshareddata/xcschemes/MarkEditMac (zh-Hant).xcscheme
+++ b/MarkEdit.xcodeproj/xcshareddata/xcschemes/MarkEditMac (zh-Hant).xcscheme
@@ -52,6 +52,15 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Kill Debug Process"
+               scriptText = "id=$(pgrep MarkEdit || true)&#10;path=$(which `ps -o comm= -p $id`)&#10;&#10;if [[ $path == *&quot;/Build/Products/Debug/&quot;* ]]; then&#10;  kill $id&#10;fi&#10;">
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference

--- a/MarkEdit.xcodeproj/xcshareddata/xcschemes/MarkEditMac.xcscheme
+++ b/MarkEdit.xcodeproj/xcshareddata/xcschemes/MarkEditMac.xcscheme
@@ -51,6 +51,15 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Kill Debug Process"
+               scriptText = "id=$(pgrep MarkEdit || true)&#10;path=$(which `ps -o comm= -p $id`)&#10;&#10;if [[ $path == *&quot;/Build/Products/Debug/&quot;* ]]; then&#10;  kill $id&#10;fi&#10;">
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference


### PR DESCRIPTION
Xcode cannot always successfully kill the running debug process, which leads to duplicate running applications while debug.