### PR TITLE
Dim inactive lines without applying grayscale filter

### DIFF
--- a/CoreEditor/src/styling/config.ts
+++ b/CoreEditor/src/styling/config.ts
@@ -153,8 +153,7 @@ export function setFocusMode(enabled: boolean) {
     const style = document.createElement('style');
     style.textContent = `
       .cm-line:not(.cm-selectedLineRange), .cm-gutterElement:not(.cm-activeLineGutter) {
-        filter: grayscale(1);
-        opacity: 0.3;
+        opacity: 0.25;
       }
     `;
 


### PR DESCRIPTION
We are making this change because it looks better, and `filter: grayscale(1)` has poor performance working with invisibles rendering (selection mode).

Chromium does much better but unfortunately, we use WebKit.