### PR TITLE
Fix scrolling issue for the preview extension

### DIFF
--- a/CoreEditor/src/@light/index.html
+++ b/CoreEditor/src/@light/index.html
@@ -10,6 +10,14 @@
   <div id="editor"></div>
   <script type=module src="./index.ts"></script>
   <style>
+    html, body {
+      overflow: scroll !important;
+    }
+
+    .cm-editor {
+      height: 100% !important;
+    }
+
     .cm-content {
       padding-top: 4px !important;
       padding-bottom: 4px !important;


### PR DESCRIPTION
In Finder, preview extension doesn't always have the correct initial offset.