### PR TITLE
Enable allowsMagnification for page zooming

### DIFF
--- a/MarkEditMac/Base.lproj/Main.storyboard
+++ b/MarkEditMac/Base.lproj/Main.storyboard
@@ -734,6 +734,25 @@ Gw
                                                 <action selector="runToolbarCustomizationPalette:" target="Ady-hI-5gd" id="pQI-g3-MTW"/>
                                             </connections>
                                         </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="PIb-KM-OZU"/>
+                                        <menuItem title="Actual Size" keyEquivalent="0" id="Sqh-CT-2fi">
+                                            <modifierMask key="keyEquivalentModifierMask" shift="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="actualSize:" target="Ady-hI-5gd" id="avZ-yK-5VZ"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Zoom In" keyEquivalent="." id="oTO-fv-8dv">
+                                            <modifierMask key="keyEquivalentModifierMask" shift="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="zoomIn:" target="Ady-hI-5gd" id="rEK-bF-TvL"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Zoom Out" keyEquivalent="," id="i0b-gh-V2Y">
+                                            <modifierMask key="keyEquivalentModifierMask" shift="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="zoomOut:" target="Ady-hI-5gd" id="XFO-he-wwW"/>
+                                            </connections>
+                                        </menuItem>
                                         <menuItem isSeparatorItem="YES" id="hB3-LF-h0Y"/>
                                         <menuItem title="Enter Full Screen" keyEquivalent="f" id="4J7-dP-txa">
                                             <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>

--- a/MarkEditMac/Modules/Sources/Previewer/Previewer.swift
+++ b/MarkEditMac/Modules/Sources/Previewer/Previewer.swift
@@ -30,6 +30,7 @@ public final class Previewer: NSViewController {
     config.userContentController = controller
 
     let webView = WKWebView(frame: .zero, configuration: config)
+    webView.allowsMagnification = true
     return webView
   }()
 

--- a/MarkEditMac/Sources/Editor/Controllers/EditorViewController+Menu.swift
+++ b/MarkEditMac/Sources/Editor/Controllers/EditorViewController+Menu.swift
@@ -42,6 +42,18 @@ extension EditorViewController: NSMenuItemValidation {
       return tableOfContentsMenuButton != nil
     }
 
+    if menuItem.action == #selector(actualSize(_:)) {
+      return abs(webView.magnification - 1.0) > .ulpOfOne
+    }
+
+    if menuItem.action == #selector(zoomIn(_:)) {
+      return webView.magnification < Constants.maximumZoomLevel
+    }
+
+    if menuItem.action == #selector(zoomOut(_:)) {
+      return webView.magnification > Constants.minimumZoomLevel
+    }
+
     if menuItem.action == #selector(toggleWindowFloating(_:)) {
       return view.window?.isKeyWindow == true
     }
@@ -301,6 +313,22 @@ private extension EditorViewController {
   }
 }
 
+// MARK: - View
+
+private extension EditorViewController {
+  @IBAction func actualSize(_ sender: Any?) {
+    webView.magnification = 1.0
+  }
+
+  @IBAction func zoomIn(_ sender: Any?) {
+    webView.magnification = min(Constants.maximumZoomLevel, webView.magnification + 0.1)
+  }
+
+  @IBAction func zoomOut(_ sender: Any?) {
+    webView.magnification = max(Constants.minimumZoomLevel, webView.magnification - 0.1)
+  }
+}
+
 // MARK: - Window
 
 private extension EditorViewController {
@@ -312,6 +340,11 @@ private extension EditorViewController {
 // MARK: - Private
 
 private extension EditorViewController {
+  enum Constants {
+    static let minimumZoomLevel: Double = 1.0
+    static let maximumZoomLevel: Double = 3.0
+  }
+
   func notifyFontSizeChanged() {
     NotificationCenter.default.post(
       name: .fontSizeChanged,

--- a/MarkEditMac/Sources/Editor/Controllers/EditorViewController.swift
+++ b/MarkEditMac/Sources/Editor/Controllers/EditorViewController.swift
@@ -94,6 +94,7 @@ final class EditorViewController: NSViewController {
     config.userContentController = controller
 
     let webView = EditorWebView(frame: .zero, configuration: config)
+    webView.allowsMagnification = true
     webView.uiDelegate = self
     webView.menuDelegate = self
 

--- a/MarkEditMac/zh-Hans.lproj/Main.strings
+++ b/MarkEditMac/zh-Hans.lproj/Main.strings
@@ -202,6 +202,9 @@
 /* Class = "NSMenu"; title = "Services"; ObjectID = "hz9-B4-Xy5"; */
 "hz9-B4-Xy5.title" = "服务";
 
+/* Class = "NSMenuItem"; title = "Zoom Out"; ObjectID = "i0b-gh-V2Y"; */
+"i0b-gh-V2Y.title" = "缩小";
+
 /* Class = "NSMenuItem"; title = "Open…"; ObjectID = "IAo-SY-fd9"; */
 "IAo-SY-fd9.title" = "打开…";
 
@@ -270,6 +273,9 @@
 
 /* Class = "NSMenuItem"; title = "Export to EPUB"; ObjectID = "ORv-QM-Kju"; */
 "ORv-QM-Kju.title" = "导出到 EPUB";
+
+/* Class = "NSMenuItem"; title = "Zoom In"; ObjectID = "oTO-fv-8dv"; */
+"oTO-fv-8dv.title" = "放大";
 
 /* Class = "NSMenuItem"; title = "Find Previous"; ObjectID = "OwM-mh-QMV"; */
 "OwM-mh-QMV.title" = "查找上一个";
@@ -342,6 +348,9 @@
 
 /* Class = "NSMenuItem"; title = "Math Block"; ObjectID = "Sqc-7N-3lD"; */
 "Sqc-7N-3lD.title" = "块状公式";
+
+/* Class = "NSMenuItem"; title = "Actual Size"; ObjectID = "Sqh-CT-2fi"; */
+"Sqh-CT-2fi.title" = "实际大小";
 
 /* Class = "NSMenu"; title = "Window"; ObjectID = "Td7-aD-5lo"; */
 "Td7-aD-5lo.title" = "窗口";

--- a/MarkEditMac/zh-Hant.lproj/Main.strings
+++ b/MarkEditMac/zh-Hant.lproj/Main.strings
@@ -202,6 +202,9 @@
 /* Class = "NSMenu"; title = "Services"; ObjectID = "hz9-B4-Xy5"; */
 "hz9-B4-Xy5.title" = "服務";
 
+/* Class = "NSMenuItem"; title = "Zoom Out"; ObjectID = "i0b-gh-V2Y"; */
+"i0b-gh-V2Y.title" = "縮小";
+
 /* Class = "NSMenuItem"; title = "Open…"; ObjectID = "IAo-SY-fd9"; */
 "IAo-SY-fd9.title" = "打開…";
 
@@ -270,6 +273,9 @@
 
 /* Class = "NSMenuItem"; title = "Export to EPUB"; ObjectID = "ORv-QM-Kju"; */
 "ORv-QM-Kju.title" = "輸出為 EPUB";
+
+/* Class = "NSMenuItem"; title = "Zoom In"; ObjectID = "oTO-fv-8dv"; */
+"oTO-fv-8dv.title" = "放大";
 
 /* Class = "NSMenuItem"; title = "Find Previous"; ObjectID = "OwM-mh-QMV"; */
 "OwM-mh-QMV.title" = "尋找上一個";
@@ -342,6 +348,9 @@
 
 /* Class = "NSMenuItem"; title = "Math Block"; ObjectID = "Sqc-7N-3lD"; */
 "Sqc-7N-3lD.title" = "塊狀公式";
+
+/* Class = "NSMenuItem"; title = "Actual Size"; ObjectID = "Sqh-CT-2fi"; */
+"Sqh-CT-2fi.title" = "實際大小";
 
 /* Class = "NSMenu"; title = "Window"; ObjectID = "Td7-aD-5lo"; */
 "Td7-aD-5lo.title" = "視窗";

--- a/PreviewExtension/PreviewViewController.swift
+++ b/PreviewExtension/PreviewViewController.swift
@@ -19,7 +19,9 @@ final class PreviewViewController: NSViewController, QLPreviewingController {
       config.setValue(false, forKey: "drawsBackground")
     }
 
-    return WKWebView(frame: .zero, configuration: config)
+    let webView = WKWebView(frame: .zero, configuration: config)
+    webView.allowsMagnification = true
+    return webView
   }()
 
   override var nibName: NSNib.Name? {


### PR DESCRIPTION
Just like TextEdit, we can now zoom in the page using trackpad gestures and menu bar actions.

Key-bindings and menu items are aligned with TextEdit.