### PR TITLE
Fix misleading comments

### DIFF
--- a/MarkEditMac/Sources/Editor/Models/EditorDocument.swift
+++ b/MarkEditMac/Sources/Editor/Models/EditorDocument.swift
@@ -208,7 +208,7 @@ extension EditorDocument {
     }
 
     // Ideally we should be able to print WKWebView,
-    // but it doesn't work very well even on Ventura.
+    // but it doesn't work well because of the lazily rendering strategy used in CodeMirror.
     //
     // For now let's just print plain text,
     // we don't expect printing to be used a lot.


### PR DESCRIPTION
Took another look, it turns out we cannot have printing due to limitations of CodeMirror.