### PR TITLE
[macOS 14] Fix changing inlinePredictions setting doesn't work

### DIFF
--- a/MarkEditKit/Sources/Extensions/NSObject+Extension.swift
+++ b/MarkEditKit/Sources/Extensions/NSObject+Extension.swift
@@ -7,16 +7,44 @@
 import Foundation
 
 public extension NSObject {
+  /// Exchange two class methods during runtime.
+  static func exchangeClassMethods(originalSelector: Selector, swizzledSelector: Selector) {
+    exchangeImplementations(
+      originalSelector: originalSelector,
+      originalMethod: class_getClassMethod(Self.self, originalSelector),
+      swizzledSelector: swizzledSelector,
+      swizzledMethod: class_getClassMethod(Self.self, swizzledSelector)
+    )
+  }
+
   /// Exchange two instance methods during runtime.
   static func exchangeInstanceMethods(originalSelector: Selector, swizzledSelector: Selector) {
-    let type = Self.self
+    exchangeImplementations(
+      originalSelector: originalSelector,
+      originalMethod: class_getInstanceMethod(Self.self, originalSelector),
+      swizzledSelector: swizzledSelector,
+      swizzledMethod: class_getInstanceMethod(Self.self, swizzledSelector)
+    )
+  }
+}
 
-    guard let originalMethod = class_getInstanceMethod(type, originalSelector) else {
+// MARK: - Private
+
+private extension NSObject {
+  /// Exchange two implementations during runtime.
+  static func exchangeImplementations(
+    originalSelector: Selector,
+    originalMethod: Method?,
+    swizzledSelector: Selector,
+    swizzledMethod: Method?
+  ) {
+    let type = Self.self
+    guard let originalMethod else {
       Logger.assertFail("Failed to swizzle: \(type), missing original method")
       return
     }
 
-    guard let swizzledMethod = class_getInstanceMethod(type, swizzledSelector) else {
+    guard let swizzledMethod else {
       Logger.assertFail("Failed to swizzle: \(type), missing swizzled method")
       return
     }

--- a/MarkEditMac/Modules/Sources/Previewer/Previewer.swift
+++ b/MarkEditMac/Modules/Sources/Previewer/Previewer.swift
@@ -109,10 +109,10 @@ public final class Previewer: NSViewController {
 
 // MARK: - WKScriptMessageHandler
 
-extension Previewer {
+private extension Previewer {
   // Break the retain cycle inside message handler,
   // to keep it simple, we are not using a delegate here.
-  private class MessageHandler: NSObject, WKScriptMessageHandler {
+  class MessageHandler: NSObject, WKScriptMessageHandler {
     private weak var host: Previewer?
 
     init(host: Previewer? = nil) {
@@ -124,7 +124,7 @@ extension Previewer {
     }
   }
 
-  private func didReceive(message: WKScriptMessage) {
+  func didReceive(message: WKScriptMessage) {
     if let body = message.body as? [String: Double], let height = body["height"], height > 0 {
       popover?.contentSize = CGSize(width: view.frame.width, height: max(height, Constants.minimumHeight))
     }

--- a/MarkEditMac/Sources/Editor/Controllers/EditorViewController+Completion.swift
+++ b/MarkEditMac/Sources/Editor/Controllers/EditorViewController+Completion.swift
@@ -70,7 +70,7 @@ extension EditorViewController {
 
 // MARK: - Panels
 
-extension EditorViewController {
+private extension EditorViewController {
   func updateCompletionPanel(isVisible: Bool) {
     let changed = completionContext.isPanelVisible != isVisible
     if isVisible {
@@ -90,7 +90,7 @@ extension EditorViewController {
     }
   }
 
-  private func updateCompletionPanel(completions: [String]) {
+  func updateCompletionPanel(completions: [String]) {
     guard completionContext.isPanelVisible else {
       return
     }
@@ -105,7 +105,7 @@ extension EditorViewController {
     }
   }
 
-  private func updateCompletionPanel(completions: [String], caretRect: CGRect) {
+  func updateCompletionPanel(completions: [String], caretRect: CGRect) {
     guard completionContext.isPanelVisible, let parentWindow = view.window else {
       return
     }

--- a/MarkEditMac/Sources/Editor/Controllers/EditorViewController+Config.swift
+++ b/MarkEditMac/Sources/Editor/Controllers/EditorViewController+Config.swift
@@ -80,8 +80,8 @@ extension EditorViewController {
   }
 
   func setInlinePredictions(enabled: Bool) {
-    // [macOS 14] Changing this won't work without recreating the WebView
-    webView.configuration.setAllowsInlinePredictions(enabled)
+    let webKitEnabled = NSSpellChecker.InlineCompletion.webKitEnabled
+    webView.configuration.setAllowsInlinePredictions(enabled && webKitEnabled)
   }
 
   func setSuggestWhileTyping(enabled: Bool) {

--- a/MarkEditMac/Sources/Editor/Controllers/EditorViewController.swift
+++ b/MarkEditMac/Sources/Editor/Controllers/EditorViewController.swift
@@ -89,7 +89,7 @@ final class EditorViewController: NSViewController {
     controller.addScriptMessageHandler(handler, contentWorld: .page, name: "bridge")
 
     let config: WKWebViewConfiguration = .newConfig()
-    config.setAllowsInlinePredictions(AppPreferences.Assistant.inlinePredictions)
+    config.setAllowsInlinePredictions(NSSpellChecker.InlineCompletion.webKitEnabled)
 
     config.processPool = EditorReusePool.shared.processPool
     config.userContentController = controller

--- a/MarkEditMac/Sources/Main/AppPreferences.swift
+++ b/MarkEditMac/Sources/Main/AppPreferences.swift
@@ -160,6 +160,7 @@ enum AppPreferences {
     @Storage(key: "assistant.inline-predictions", defaultValue: true)
     static var inlinePredictions: Bool {
       didSet {
+        NSSpellChecker.InlineCompletion.spellCheckerEnabled = inlinePredictions
         performUpdates { $0.setInlinePredictions(enabled: inlinePredictions) }
       }
     }

--- a/MarkEditMac/Sources/Main/Application/AppDelegate.swift
+++ b/MarkEditMac/Sources/Main/Application/AppDelegate.swift
@@ -46,8 +46,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     UserDefaults.overwriteTextCheckerOnce()
-    NSSpellChecker.swizzleCorrectionIndicatorOnce
     EditorCustomization.createFiles()
+
+    NSSpellChecker.swizzleInlineCompletionEnabledOnce
+    NSSpellChecker.swizzleCorrectionIndicatorOnce
 
     NotificationCenter.default.addObserver(
       self,
@@ -67,7 +69,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 // MARK: - Private
 
 private extension AppDelegate {
-  @objc private func windowDidResignKey(_ notification: Notification) {
+  @objc func windowDidResignKey(_ notification: Notification) {
     // Cancel completion when an editor is no longer the key window
     if let editor = (notification.object as? NSWindow)?.contentViewController as? EditorViewController {
       editor.cancelCompletion()


### PR DESCRIPTION
As a follow-up to #185, this PR fixes changing the option doesn't work before re-opening the document.

In addition, made some minor code convention changes.

Related: https://github.com/WebKit/WebKit/blob/1f2d2a92eeb831bedd01bbb5b694a0e29fa9af81/Source/WebKit/UIProcess/mac/WebViewImpl.mm#L5190