### PR TITLE
Ensure runtime magic with more tests

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -41,6 +41,10 @@ jobs:
         run: |
           xcodebuild test -project ../MarkEdit.xcodeproj -scheme MarkEditCoreTests -destination 'platform=macOS'
 
+      - name: Test MarkEditMacTests
+        run: |
+          xcodebuild test -project ../MarkEdit.xcodeproj -scheme MarkEditMacTests -destination 'platform=macOS'
+
       - name: Test ModulesTests
         run: |
           xcodebuild test -project ../MarkEdit.xcodeproj -scheme ModulesTests -destination 'platform=macOS'

--- a/MarkEdit.xcodeproj/project.pbxproj
+++ b/MarkEdit.xcodeproj/project.pbxproj
@@ -24,7 +24,8 @@
 		870F17922985775B00003DA7 /* Previewer in Frameworks */ = {isa = PBXBuildFile; productRef = 870F17912985775B00003DA7 /* Previewer */; };
 		870F17942985775B00003DA7 /* Proofing in Frameworks */ = {isa = PBXBuildFile; productRef = 870F17932985775B00003DA7 /* Proofing */; };
 		870F17962985775B00003DA7 /* SettingsUI in Frameworks */ = {isa = PBXBuildFile; productRef = 870F17952985775B00003DA7 /* SettingsUI */; };
-		870FF83A298BD7DC00E4AE99 /* MarkEditMacTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 870FF839298BD7DC00E4AE99 /* MarkEditMacTests.swift */; };
+		870FF83A298BD7DC00E4AE99 /* BundleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 870FF839298BD7DC00E4AE99 /* BundleTests.swift */; };
+		871A2F4D2A4BD22F0080E3F5 /* RuntimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 871A2F4C2A4BD22F0080E3F5 /* RuntimeTests.swift */; };
 		871C995B2973F1E6003FF3A7 /* AppDelegate+Document.swift in Sources */ = {isa = PBXBuildFile; fileRef = 871C995A2973F1E6003FF3A7 /* AppDelegate+Document.swift */; };
 		871C995D2973F20E003FF3A7 /* AppDelegate+Menu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 871C995C2973F20E003FF3A7 /* AppDelegate+Menu.swift */; };
 		8723B46929C0A6EA0013D5D5 /* EvaluateJavaScriptIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8723B46829C0A6EA0013D5D5 /* EvaluateJavaScriptIntent.swift */; };
@@ -128,7 +129,8 @@
 		870F17752985546500003DA7 /* MarkEditCore */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = MarkEditCore; sourceTree = "<group>"; };
 		870F178C2985774D00003DA7 /* Modules */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = Modules; sourceTree = "<group>"; };
 		870FF837298BD7DC00E4AE99 /* MarkEditMacTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MarkEditMacTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		870FF839298BD7DC00E4AE99 /* MarkEditMacTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkEditMacTests.swift; sourceTree = "<group>"; };
+		870FF839298BD7DC00E4AE99 /* BundleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleTests.swift; sourceTree = "<group>"; };
+		871A2F4C2A4BD22F0080E3F5 /* RuntimeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuntimeTests.swift; sourceTree = "<group>"; };
 		871C995A2973F1E6003FF3A7 /* AppDelegate+Document.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+Document.swift"; sourceTree = "<group>"; };
 		871C995C2973F20E003FF3A7 /* AppDelegate+Menu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+Menu.swift"; sourceTree = "<group>"; };
 		87231E77298E77D800251D09 /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/Main.strings"; sourceTree = "<group>"; };
@@ -322,7 +324,8 @@
 		870FF838298BD7DC00E4AE99 /* MarkEditMacTests */ = {
 			isa = PBXGroup;
 			children = (
-				870FF839298BD7DC00E4AE99 /* MarkEditMacTests.swift */,
+				870FF839298BD7DC00E4AE99 /* BundleTests.swift */,
+				871A2F4C2A4BD22F0080E3F5 /* RuntimeTests.swift */,
 			);
 			path = MarkEditMacTests;
 			sourceTree = "<group>";
@@ -699,7 +702,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				870FF83A298BD7DC00E4AE99 /* MarkEditMacTests.swift in Sources */,
+				871A2F4D2A4BD22F0080E3F5 /* RuntimeTests.swift in Sources */,
+				870FF83A298BD7DC00E4AE99 /* BundleTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MarkEdit.xcodeproj/xcshareddata/xcschemes/MarkEditMacTests.xcscheme
+++ b/MarkEdit.xcodeproj/xcshareddata/xcschemes/MarkEditMacTests.xcscheme
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1430"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "870FF836298BD7DC00E4AE99"
+               BuildableName = "MarkEditMacTests.xctest"
+               BlueprintName = "MarkEditMacTests"
+               ReferencedContainer = "container:MarkEdit.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/MarkEditMacTests/BundleTests.swift
+++ b/MarkEditMacTests/BundleTests.swift
@@ -1,5 +1,5 @@
 //
-//  MarkEditMacTests.swift
+//  BundleTests.swift
 //  MarkEditMacTests
 //
 //  Created by cyan on 2/2/23.
@@ -7,7 +7,7 @@
 
 import XCTest
 
-final class MarkEditMacTests: XCTestCase {
+final class BundleTests: XCTestCase {
   func testExistenceOfAppIcon() {
     XCTAssertNotNil(NSImage(named: "AppIcon"), "Missing AppIcon from the main bundle")
   }

--- a/MarkEditMacTests/RuntimeTests.swift
+++ b/MarkEditMacTests/RuntimeTests.swift
@@ -1,0 +1,88 @@
+//
+//  RuntimeTests.swift
+//  MarkEditMacTests
+//
+//  Created by cyan on 6/28/23.
+//
+
+import XCTest
+import WebKit
+
+final class RuntimeTests: XCTestCase {
+  func testExistenceOfAllowsInlinePredictions() {
+    guard #available(macOS 14.0, *) else {
+      return
+    }
+
+    // [macOS 14] Remove after WebKit exposes this as public
+    let configuration = WKWebViewConfiguration()
+    configuration.setValue(true, forKey: "allowsInlinePredictions")
+    testExistenceOfSelector(object: configuration, selector: "setAllowsInlinePredictions:")
+  }
+
+  func testExistenceOfDrawsBackground() {
+    let configuration = WKWebViewConfiguration()
+    configuration.setValue(false, forKey: "drawsBackground")
+    testExistenceOfSelector(object: configuration, selector: "_drawsBackground")
+  }
+
+  func testExistenceOfDeveloperExtras() {
+    let preferences = WKWebViewConfiguration().preferences
+    preferences.setValue(true, forKey: "developerExtrasEnabled")
+    testExistenceOfSelector(object: preferences, selector: "_developerExtrasEnabled")
+  }
+
+  func testExistenceOfAutomaticInlineCompletion() {
+    guard #available(macOS 14.0, *) else {
+      return
+    }
+
+    let checker = NSSpellChecker.self
+    testExistenceOfSelector(object: checker, selector: "isAutomaticInlineCompletionEnabled")
+  }
+
+  func testExistenceOfCancelCorrection() {
+    let checker = NSSpellChecker()
+    testExistenceOfSelector(object: checker, selector: "cancelCorrectionIndicatorForView:")
+  }
+
+  func testRetrievingPopover() {
+    class ContentViewController: NSViewController {
+      override func loadView() {
+        view = NSView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
+      }
+    }
+
+    let window = NSWindow()
+    window.makeKeyAndOrderFront(nil)
+
+    guard let contentView = window.contentView else {
+      XCTAssert(false, "Missing contentView in NSWindow")
+      return
+    }
+
+    let popover = NSPopover()
+    popover.contentViewController = ContentViewController(nibName: nil, bundle: nil)
+    popover.show(
+      relativeTo: CGRect(x: 0, y: 0, width: 1, height: 1),
+      of: contentView,
+      preferredEdge: .maxX
+    )
+
+    let expectation = XCTestExpectation()
+    DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+      expectation.fulfill()
+    }
+
+    wait(for: [expectation])
+    XCTAssertNotNil(popover.contentViewController?.view.window?.value(forKey: "_popover"))
+  }
+}
+
+// MARK: - Private
+
+private extension RuntimeTests {
+  func testExistenceOfSelector(object: AnyObject, selector: String) {
+    XCTAssert(object.responds(to: sel_getUid(selector)), "Missing \(selector) in \(object.self)")
+  }
+}


### PR DESCRIPTION
We have done lots of runtime magic because we didn't have better choices, which are fragile and can be protected by unit tests.