### PR TITLE
Remove "suppressImplicitAnyIndexErrors" as it's deprecated

### DIFF
--- a/CoreEditor/tsconfig.json
+++ b/CoreEditor/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "node",
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
-    "suppressImplicitAnyIndexErrors": true,
     "strictNullChecks": true,
     "experimentalDecorators": true,
     "importHelpers": true,


### PR DESCRIPTION
It is used to suppress warnings from code like this:

```ts
const obj = { x: 10 };
console.log(obj["foo"]);
```

Ref: https://www.typescriptlang.org/tsconfig#suppressImplicitAnyIndexErrors.