### PR TITLE
Reinvent :hover to stop the WebKit madness

### DIFF
--- a/CoreEditor/index.css
+++ b/CoreEditor/index.css
@@ -22,8 +22,8 @@ html, body {
   -webkit-touch-callout: none;
   -webkit-user-select: none;
 
-  /* To work around a Safari bug where :hover is not cleared when mouse is outside the window */
-  margin: 0px 1px;
+  /* To work around a WebKit bug where :hover is not cleared when mouse is outside the window */
+  margin: 1px;
 }
 
 /* Markdown */

--- a/CoreEditor/src/bridge/web/core.ts
+++ b/CoreEditor/src/bridge/web/core.ts
@@ -1,5 +1,15 @@
 import { WebModule } from '../webModule';
-import { ReplaceGranularity, resetEditor, clearEditor, getEditorText, insertText, replaceText, markEditorDirty } from '../../core';
+import {
+  ReplaceGranularity,
+  resetEditor,
+  clearEditor,
+  getEditorText,
+  insertText,
+  replaceText,
+  markEditorDirty,
+  handleMouseEntered,
+  handleMouseExited,
+} from '../../core';
 
 /**
  * @shouldExport true
@@ -13,6 +23,8 @@ export interface WebModuleCore extends WebModule {
   insertText({ text, from, to }: { text: string; from: CodeGen_Int; to: CodeGen_Int }): void;
   replaceText({ text, granularity }: { text: string; granularity: ReplaceGranularity }): void;
   markEditorDirty({ isDirty }: { isDirty: boolean }): void;
+  handleMouseEntered({ clientX, clientY }: { clientX: number; clientY: number } ): void;
+  handleMouseExited({ clientX, clientY }: { clientX: number; clientY: number } ): void;
 }
 
 export class WebModuleCoreImpl implements WebModuleCore {
@@ -38,5 +50,13 @@ export class WebModuleCoreImpl implements WebModuleCore {
 
   markEditorDirty({ isDirty }: { isDirty: boolean }): void {
     markEditorDirty(isDirty);
+  }
+
+  handleMouseEntered({ clientX, clientY }: { clientX: number; clientY: number }): void {
+    handleMouseEntered(clientX, clientY);
+  }
+
+  handleMouseExited({ clientX, clientY }: { clientX: number; clientY: number }): void {
+    handleMouseExited(clientX, clientY);
   }
 }

--- a/CoreEditor/src/core.ts
+++ b/CoreEditor/src/core.ts
@@ -66,11 +66,6 @@ export function resetEditor(doc: string) {
     })();
   });
 
-  const gutterDOM = document.querySelector('.cm-gutters') as HTMLElement | null;
-  if (gutterDOM !== null) {
-    gutterDOM.addEventListener('mouseenter', () => styling.setGutterHoverDelay(false));
-  }
-
   // Recofigure, window.config might have changed
   styling.setUp(window.config, themes.loadTheme(window.config.theme).accentColor);
 
@@ -136,6 +131,27 @@ export function replaceText(text: string, granularity: ReplaceGranularity) {
 
 export function markEditorDirty(isDirty: boolean) {
   editingState.isDirty = isDirty;
+}
+
+export function handleMouseEntered(clientX: number, _clientY: number) {
+  const gutterDOM = document.querySelector('.cm-gutters') as HTMLElement | null;
+  if (gutterDOM === null) {
+    return;
+  }
+
+  const gutterRect = gutterDOM.getBoundingClientRect();
+  const rightToLeft = gutterRect.left > 20;
+
+  // Check if the point is inside the gutters, RTL is guessed with a margin.
+  //
+  // To keep it simple, this doesn't take magnification into account.
+  if (clientX > 0 && clientX < gutterRect.width || rightToLeft && clientX > gutterRect.left && clientX < gutterRect.right) {
+    styling.setGutterHovered(true);
+  }
+}
+
+export function handleMouseExited(_clientX: number, _clientY: number) {
+  styling.setGutterHovered(false);
 }
 
 function fixWebKitWheelIssues(scrollDOM: HTMLElement) {

--- a/CoreEditor/src/events/index.ts
+++ b/CoreEditor/src/events/index.ts
@@ -1,6 +1,5 @@
 import isMetaKey from './isMetaKey';
 import { editingState } from '../common/store';
-import { setGutterHoverDelay } from '../styling/config';
 
 import * as completion from '../modules/completion';
 import * as grammarly from '../modules/grammarly';
@@ -27,13 +26,13 @@ export function startObserving() {
   });
 
   document.addEventListener('mousedown', event => {
+    storage.isMouseDown = true;
     link.handleMouseDown(event);
-    setGutterHoverDelay(true);
   }, true);
 
   document.addEventListener('mouseup', event => {
+    storage.isMouseDown = false;
     link.handleMouseUp(event);
-    setGutterHoverDelay(false);
   }, true);
 
   document.addEventListener('compositionstart', () => {
@@ -54,6 +53,10 @@ export function startObserving() {
 
   observeEventsForTokenization();
   observeEventsForCompletion();
+}
+
+export function isMouseDown() {
+  return storage.isMouseDown;
 }
 
 function observeEventsForTokenization() {
@@ -106,3 +109,5 @@ function observeEventsForCompletion() {
     }
   }, true);
 }
+
+const storage: { isMouseDown: boolean } = { isMouseDown: false };

--- a/CoreEditor/src/styling/builder.ts
+++ b/CoreEditor/src/styling/builder.ts
@@ -40,6 +40,9 @@ const sharedStyles: { [selector: string]: StyleSpec } = {
     opacity: '0',
     transition: '0.4s',
   },
+  '.cm-foldGutter.cm-gutterHover': {
+    opacity: '1',
+  },
   '.cm-foldGutter, .cm-foldPlaceholder': {
     /* We don't use ui-monospace here because ▶︎ and ••• look very big */
     fontFamily: 'monospace',
@@ -53,9 +56,6 @@ const sharedStyles: { [selector: string]: StyleSpec } = {
   '.cm-gutters': {
     borderRight: 'none',
     fontFamily: 'ui-monospace, monospace',
-  },
-  '.cm-gutters:hover .cm-foldGutter:not(:hover), .cm-foldGutter:hover': {
-    opacity: '1',
   },
   '.cm-activeLineGutter': {
     backgroundColor: 'inherit',

--- a/MarkEditKit/Sources/Bridge/Web/Generated/WebBridgeCore.swift
+++ b/MarkEditKit/Sources/Bridge/Web/Generated/WebBridgeCore.swift
@@ -83,6 +83,34 @@ public final class WebBridgeCore {
 
     webView?.invoke(path: "webModules.core.markEditorDirty", message: message, completion: completion)
   }
+
+  public func handleMouseEntered(clientX: Double, clientY: Double, completion: ((Result<Void, WKWebView.InvokeError>) -> Void)? = nil) {
+    struct Message: Encodable {
+      let clientX: Double
+      let clientY: Double
+    }
+
+    let message = Message(
+      clientX: clientX,
+      clientY: clientY
+    )
+
+    webView?.invoke(path: "webModules.core.handleMouseEntered", message: message, completion: completion)
+  }
+
+  public func handleMouseExited(clientX: Double, clientY: Double, completion: ((Result<Void, WKWebView.InvokeError>) -> Void)? = nil) {
+    struct Message: Encodable {
+      let clientX: Double
+      let clientY: Double
+    }
+
+    let message = Message(
+      clientX: clientX,
+      clientY: clientY
+    )
+
+    webView?.invoke(path: "webModules.core.handleMouseExited", message: message, completion: completion)
+  }
 }
 
 public enum ReplaceGranularity: String, Codable {

--- a/MarkEditMac/Sources/Editor/Controllers/EditorViewController.swift
+++ b/MarkEditMac/Sources/Editor/Controllers/EditorViewController.swift
@@ -15,6 +15,7 @@ import TextCompletion
 final class EditorViewController: NSViewController {
   var hasFinishedLoading = false
   var hasUnfinishedAnimations = false
+  var mouseExitedWindow = false
   var safeAreaObservation: NSKeyValueObservation?
   weak var presentedPopover: NSPopover?
 


### PR DESCRIPTION
It seems `:hover` doesn't work reliably in WebKit. It's very often to see `mouseup` is not triggered when mouse is outside the window, hence `:hover` is not cleared.

This change improves it by leveraging `NSEvent`, also makes `foldGutter` doesn't blink when clicked.