### PR TITLE
Change assertion in toolbarEffectView to a test

### DIFF
--- a/MarkEditMac/Modules/Sources/AppKitExtensions/UI/NSWindow+Extension.swift
+++ b/MarkEditMac/Modules/Sources/AppKitExtensions/UI/NSWindow+Extension.swift
@@ -17,7 +17,6 @@ public extension NSWindow {
       effectView.superview?.className.hasPrefix("NSTitlebar") == true
     }
 
-    assert(result != nil, "Failed to find NSVisualEffectView in toolbar")
     return result
   }
 

--- a/MarkEditMacTests/RuntimeTests.swift
+++ b/MarkEditMacTests/RuntimeTests.swift
@@ -7,6 +7,7 @@
 
 import XCTest
 import WebKit
+import AppKitExtensions
 
 final class RuntimeTests: XCTestCase {
   func testExistenceOfAllowsInlinePredictions() {
@@ -76,6 +77,12 @@ final class RuntimeTests: XCTestCase {
 
     wait(for: [expectation])
     XCTAssertNotNil(popover.contentViewController?.view.window?.value(forKey: "_popover"))
+  }
+
+  func testRetrievingToolbarEffectView() {
+    let window = NSWindow()
+    window.makeKeyAndOrderFront(nil)
+    XCTAssertNotNil(window.toolbarEffectView)
   }
 }
 


### PR DESCRIPTION
When maximizing the window, `toolbarEffectView` is indeed nil. Luckily this doesn't affect release build.