### PR TITLE
Fix issues working with CRLF

### DIFF
--- a/CoreEditor/src/core.ts
+++ b/CoreEditor/src/core.ts
@@ -27,12 +27,15 @@ export function resetEditor(doc: string) {
     window.editor.destroy();
   }
 
-  const editor = new EditorView({
+  const lineBreak = lineEndings.getLineBreak(
     doc,
+    window.config.defaultLineBreak
+  );
+
+  const editor = new EditorView({
+    doc: lineEndings.normalizeLineBreaks(doc, lineBreak),
     parent: document.querySelector('#editor') ?? document.body,
-    extensions: extensions({
-      lineBreak: lineEndings.getLineBreak(doc, window.config.defaultLineBreak),
-    }),
+    extensions: extensions({ lineBreak }),
   });
 
   editor.focus();

--- a/CoreEditor/src/modules/commands/formatContent.ts
+++ b/CoreEditor/src/modules/commands/formatContent.ts
@@ -1,3 +1,5 @@
+import { getEditorText } from '../../core';
+
 /**
  * Format the content, usually gets called when saving files.
  *
@@ -10,7 +12,7 @@ export default function formatContent(insertFinalNewline: boolean, trimTrailingW
 
   if (insertFinalNewline) {
     // We don't need to ensure final newline when it's empty
-    const text = state.doc.toString();
+    const text = getEditorText();
     if (text.length > 0 && !text.endsWith(state.lineBreak)) {
       editor.dispatch({
         changes: {

--- a/CoreEditor/src/modules/lineEndings/index.ts
+++ b/CoreEditor/src/modules/lineEndings/index.ts
@@ -67,4 +67,25 @@ export function getLineBreak(string: string, defaultValue?: string) {
   }
 }
 
+export function normalizeLineBreaks(input: string, lineBreak: string | undefined) {
+  if (lineBreak === undefined) {
+    return input;
+  }
+
+  // 1. \r\n -> \n
+  // 2. \r -> \n
+  // 3. \n -> lineBreak if necessary
+  //
+  // Order matters; it may not be the fastest, but it's easy to understand.
+  let output = input;
+  output = output.replace(new RegExp(CHARS.CRLF, 'g'), CHARS.LF);
+  output = output.replace(new RegExp(CHARS.CR, 'g'), CHARS.LF);
+
+  if (lineBreak !== CHARS.LF) {
+    output = output.replace(new RegExp(CHARS.LF, 'g'), lineBreak);
+  }
+
+  return output;
+}
+
 export type { LineEndings };

--- a/CoreEditor/src/styling/themes/index.ts
+++ b/CoreEditor/src/styling/themes/index.ts
@@ -13,7 +13,7 @@ import MinimalDark from './minimal-dark';
 import SynthWave84 from './synthwave84';
 import NightOwl from './night-owl';
 
-const themes = {
+const themes: { [key: string]: (() => EditorTheme) | undefined } = {
   'github-light': GitHubLight,
   'github-dark': GitHubDark,
   'xcode-light': XcodeLight,

--- a/CoreEditor/test/lineEndings.test.ts
+++ b/CoreEditor/test/lineEndings.test.ts
@@ -33,4 +33,16 @@ describe('LineEndings module', () => {
     expect(lineEndings.getLineBreak('', '\r')).toBe('\r');
     expect(lineEndings.getLineBreak('', '\r\n')).toBe('\r\n');
   });
+
+  test('test normalizing line breaks', () => {
+    expect(lineEndings.normalizeLineBreaks('Hello\nWorld', undefined)).toBe('Hello\nWorld');
+    expect(lineEndings.normalizeLineBreaks('Hello\nWorld', '\n')).toBe('Hello\nWorld');
+    expect(lineEndings.normalizeLineBreaks('Hello\n\r\nWorld', '\n')).toBe('Hello\n\nWorld');
+    expect(lineEndings.normalizeLineBreaks('Hello\n\n\r\nWorld', '\n')).toBe('Hello\n\n\nWorld');
+    expect(lineEndings.normalizeLineBreaks('Hello\n\r\rWorld', '\n')).toBe('Hello\n\n\nWorld');
+    expect(lineEndings.normalizeLineBreaks('Hello\r\nWorld', '\n')).toBe('Hello\nWorld');
+    expect(lineEndings.normalizeLineBreaks('Hello\r\nWorld', '\r')).toBe('Hello\rWorld');
+    expect(lineEndings.normalizeLineBreaks('Hello\r\nWorld', '\r\n')).toBe('Hello\r\nWorld');
+    expect(lineEndings.normalizeLineBreaks('Hello\r\n\r\n\n\nWorld', '\r\n')).toBe('Hello\r\n\r\n\r\n\r\nWorld');
+  });
 });


### PR DESCRIPTION
Two issues:

- CRLF doesn't work well with the `insertFinalNewline` option
- Line breaks are not normalized, e.g., files are changed by TextEdit (only use LF)