### PR TITLE
Improve the fix for scrollDOM offset

### DIFF
--- a/CoreEditor/src/core.ts
+++ b/CoreEditor/src/core.ts
@@ -47,6 +47,7 @@ export function resetEditor(doc: string) {
   editor.dispatch({ effects: EditorView.scrollIntoView(0) });
 
   const scrollDOM = editor.scrollDOM;
+  scrollDOM.scrollTo({ top: 0, behavior: 'instant' }); // scrollIntoView doesn't work when the app is idle
   fixWebKitWheelIssues(scrollDOM);
 
   scrollDOM.addEventListener('scroll', () => {


### PR DESCRIPTION
Sadly, `scrollIntoView` doesn't work when the app is idle.