### PR TITLE
Improve openPanel and autosave

### DIFF
--- a/MarkEditMac/Modules/Sources/AppKitExtensions/Foundation/NSApplication+Extension.swift
+++ b/MarkEditMac/Modules/Sources/AppKitExtensions/Foundation/NSApplication+Extension.swift
@@ -21,11 +21,27 @@ public extension NSApplication {
     } else {
       NSDocumentController.shared.openDocument(self)
     }
+
+    // [AppKit bug] NSOpenPanel is not reloaded automatically, resulting files cannot be opened.
+    //
+    // It can be reproduced after saving an iCloud file and quickly showing the openPanel,
+    // even the built-in TextEdit.app has this problem.
+    DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+      self.openPanels.forEach {
+        $0.validateVisibleColumns()
+      }
+    }
   }
 
   func closeOpenPanels() {
-    for openPanel in windows where openPanel is NSOpenPanel {
-      openPanel.close()
-    }
+    openPanels.forEach { $0.close() }
+  }
+}
+
+// MARK: - Private
+
+private extension NSApplication {
+  var openPanels: [NSOpenPanel] {
+    windows.compactMap { $0 as? NSOpenPanel }
   }
 }

--- a/MarkEditMac/Sources/Editor/Models/EditorDocument.swift
+++ b/MarkEditMac/Sources/Editor/Models/EditorDocument.swift
@@ -131,6 +131,11 @@ extension EditorDocument {
   }
 
   override func autosave(withImplicitCancellability implicitlyCancellable: Bool) async throws {
+    // The default implementation checks hasUnautosavedChanges and fails fast
+    guard hasUnautosavedChanges else {
+      return
+    }
+
     await saveAsynchronously {
       Task {
         try await super.autosave(withImplicitCancellability: implicitlyCancellable)


### PR DESCRIPTION
This PR improves two things:

- Reduce `autosave` by checking `hasUnautosavedChanges`
- Validates visible columns in openPanels in time

It's interesting that TextEdit.app also has this problem.