### PR TITLE
Improve undo stack to match native apps

### DIFF
--- a/CoreEditor/src/@test/editor.ts
+++ b/CoreEditor/src/@test/editor.ts
@@ -26,6 +26,15 @@ export function setText(doc: string) {
   });
 }
 
+export function insertText(text: string) {
+  window.editor.dispatch({
+    changes: {
+      insert: text,
+      from: window.editor.state.doc.length,
+    },
+  });
+}
+
 export function getText() {
   return window.editor.state.doc.toString();
 }

--- a/CoreEditor/src/bridge/native/core.ts
+++ b/CoreEditor/src/bridge/native/core.ts
@@ -9,6 +9,6 @@ import { LineColumnInfo } from '../../modules/selection/types';
 export interface NativeModuleCore extends NativeModule {
   notifyWindowDidLoad(): void;
   notifyViewportScaleDidChange(): void;
-  notifyTextDidChange({ undoDepth }: { undoDepth: CodeGen_Int }): void;
+  notifyTextDidChange({ isDirty }: { isDirty: boolean }): void;
   notifySelectionDidChange({ lineColumn, contentEdited }: { lineColumn: LineColumnInfo; contentEdited: boolean }): void;
 }

--- a/CoreEditor/src/bridge/web/history.ts
+++ b/CoreEditor/src/bridge/web/history.ts
@@ -1,5 +1,5 @@
 import { WebModule } from '../webModule';
-import { undo, redo, canUndo, canRedo } from '../../modules/history';
+import { undo, redo, canUndo, canRedo, saveHistory } from '../../modules/history';
 
 /**
  * @shouldExport true
@@ -11,6 +11,7 @@ export interface WebModuleHistory extends WebModule {
   redo(): void;
   canUndo(): boolean;
   canRedo(): boolean;
+  saveHistory(): void;
 }
 
 export class WebModuleHistoryImpl implements WebModuleHistory {
@@ -28,5 +29,9 @@ export class WebModuleHistoryImpl implements WebModuleHistory {
 
   canRedo(): boolean {
     return canRedo();
+  }
+
+  saveHistory(): void {
+    saveHistory();
   }
 }

--- a/CoreEditor/src/modules/history/index.ts
+++ b/CoreEditor/src/modules/history/index.ts
@@ -21,3 +21,17 @@ export function canUndo() {
 export function canRedo() {
   return redoDepth(window.editor.state) > 0;
 }
+
+export function saveHistory() {
+  // This function is called when the user saves the document, we save the current undo depth,
+  // when text changes, we use this value to calculate the "isDirty" state.
+  storage.savedUndoDepth = undoDepth(window.editor.state);
+}
+
+export function isContentDirty() {
+  // The content is "dirty" when the current undo depth is not the same as the saved depth,
+  // i.e., there re unsaved changes.
+  return storage.savedUndoDepth !== undoDepth(window.editor.state);
+}
+
+const storage: { savedUndoDepth: number } = { savedUndoDepth: 0 };

--- a/CoreEditor/src/modules/input/index.ts
+++ b/CoreEditor/src/modules/input/index.ts
@@ -1,10 +1,10 @@
 import { EditorView } from '@codemirror/view';
-import { undoDepth } from '@codemirror/commands';
 import { InvisiblesBehavior } from '../../config';
 import { editingState } from '../../common/store';
 import { selectedLineColumn } from '../selection/selectedLineColumn';
 import { setInvisiblesBehavior } from '../config';
 import { startCompletion, isPanelVisible } from '../completion';
+import { isContentDirty } from '../history';
 import { tokenizePosition } from '../tokenizer';
 import { scrollCaretToVisible, scrollToSelection } from '../../modules/selection';
 import { setShowActiveLineIndicator } from '../../styling/config';
@@ -67,9 +67,7 @@ export function observeChanges() {
       // It would be great if we could also provide the updated text here,
       // but it's time-consuming for large payload,
       // we want to be responsive for every key stroke.
-      window.nativeModules.core.notifyTextDidChange({
-        undoDepth: undoDepth(window.editor.state) as CodeGen_Int,
-      });
+      window.nativeModules.core.notifyTextDidChange({ isDirty: isContentDirty() });
     }
 
     if (update.selectionSet) {

--- a/CoreEditor/test/history.test.ts
+++ b/CoreEditor/test/history.test.ts
@@ -1,6 +1,6 @@
 import { history, undo, redo } from '@codemirror/commands';
 import { describe, expect, test } from '@jest/globals';
-import { canUndo, canRedo } from '../src/modules/history';
+import { canUndo, canRedo, saveHistory, isContentDirty } from '../src/modules/history';
 import * as editor from '../src/@test/editor';
 
 describe('History module', () => {
@@ -20,5 +20,36 @@ describe('History module', () => {
     redo(window.editor);
     expect(canUndo()).toBeTruthy();
     expect(canRedo()).toBeFalsy();
+  });
+
+  test('test isContentDirty', () => {
+    editor.setUp('Hello World', history());
+    expect(isContentDirty()).toBeFalsy();
+
+    editor.insertText('\n');
+    expect(isContentDirty()).toBeTruthy();
+
+    undo(window.editor);
+    expect(isContentDirty()).toBeFalsy();
+
+    saveHistory();
+    expect(isContentDirty()).toBeFalsy();
+
+    editor.insertText('\n');
+    editor.insertText('\n');
+    expect(isContentDirty()).toBeTruthy();
+
+    saveHistory();
+    expect(isContentDirty()).toBeFalsy();
+
+    undo(window.editor);
+    expect(isContentDirty()).toBeTruthy();
+
+    redo(window.editor);
+    expect(isContentDirty()).toBeFalsy();
+
+    undo(window.editor);
+    undo(window.editor);
+    expect(isContentDirty()).toBeTruthy();
   });
 });

--- a/MarkEditKit/Sources/Bridge/Native/Generated/NativeModuleCore.swift
+++ b/MarkEditKit/Sources/Bridge/Native/Generated/NativeModuleCore.swift
@@ -13,7 +13,7 @@ import MarkEditCore
 public protocol NativeModuleCore: NativeModule {
   func notifyWindowDidLoad()
   func notifyViewportScaleDidChange()
-  func notifyTextDidChange(undoDepth: Int)
+  func notifyTextDidChange(isDirty: Bool)
   func notifySelectionDidChange(lineColumn: LineColumnInfo, contentEdited: Bool)
 }
 
@@ -57,7 +57,7 @@ final class NativeBridgeCore: NativeBridge {
 
   private func notifyTextDidChange(parameters: Data) -> Result<Any?, Error>? {
     struct Message: Decodable {
-      var undoDepth: Int
+      var isDirty: Bool
     }
 
     let message: Message
@@ -68,7 +68,7 @@ final class NativeBridgeCore: NativeBridge {
       return .failure(error)
     }
 
-    module.notifyTextDidChange(undoDepth: message.undoDepth)
+    module.notifyTextDidChange(isDirty: message.isDirty)
     return .success(nil)
   }
 

--- a/MarkEditKit/Sources/Bridge/Native/Modules/EditorModuleCore.swift
+++ b/MarkEditKit/Sources/Bridge/Native/Modules/EditorModuleCore.swift
@@ -9,7 +9,7 @@ import Foundation
 public protocol EditorModuleCoreDelegate: AnyObject {
   func editorCoreWindowDidLoad(_ sender: EditorModuleCore)
   func editorCoreViewportScaleDidChange(_ sender: EditorModuleCore)
-  func editorCoreTextDidChange(_ sender: EditorModuleCore, undoDepth: Int)
+  func editorCoreTextDidChange(_ sender: EditorModuleCore, isDirty: Bool)
   func editorCore(
     _ sender: EditorModuleCore,
     selectionDidChange lineColumn: LineColumnInfo,
@@ -32,8 +32,8 @@ public final class EditorModuleCore: NativeModuleCore {
     delegate?.editorCoreViewportScaleDidChange(self)
   }
 
-  public func notifyTextDidChange(undoDepth: Int) {
-    delegate?.editorCoreTextDidChange(self, undoDepth: undoDepth)
+  public func notifyTextDidChange(isDirty: Bool) {
+    delegate?.editorCoreTextDidChange(self, isDirty: isDirty)
   }
 
   public func notifySelectionDidChange(lineColumn: LineColumnInfo, contentEdited: Bool) {

--- a/MarkEditKit/Sources/Bridge/Web/Generated/WebBridgeHistory.swift
+++ b/MarkEditKit/Sources/Bridge/Web/Generated/WebBridgeHistory.swift
@@ -42,4 +42,8 @@ public final class WebBridgeHistory {
       }
     }
   }
+
+  public func saveHistory(completion: ((Result<Void, WKWebView.InvokeError>) -> Void)? = nil) {
+    webView?.invoke(path: "webModules.history.saveHistory", completion: completion)
+  }
 }

--- a/MarkEditMac/Modules/Sources/AppKitExtensions/Foundation/NSDocument+Extension.swift
+++ b/MarkEditMac/Modules/Sources/AppKitExtensions/Foundation/NSDocument+Extension.swift
@@ -11,12 +11,9 @@ public extension NSDocument {
     fileURL?.deletingLastPathComponent()
   }
 
-  /// Update the change count to exactly `undoDepth`.
-  func updateChangeCount(undoDepth: Int) {
-    updateChangeCount(.changeCleared)
-
-    for _ in 0 ..< undoDepth {
-      updateChangeCount(.changeDone)
-    }
+  func markContentDirty(_ isDirty: Bool) {
+    // The undo stack is implemented in CoreEditor entirely,
+    // there are only two meaningful change count values: 0 (saved) or 1 (dirty).
+    updateChangeCount(isDirty ? .changeDone : .changeCleared)
   }
 }

--- a/MarkEditMac/Sources/Editor/Controllers/EditorViewController+Delegate.swift
+++ b/MarkEditMac/Sources/Editor/Controllers/EditorViewController+Delegate.swift
@@ -70,8 +70,8 @@ extension EditorViewController: EditorModuleCoreDelegate {
     cancelOperation(sender)
   }
 
-  func editorCoreTextDidChange(_ sender: EditorModuleCore, undoDepth: Int) {
-    document?.updateChangeCount(undoDepth: undoDepth)
+  func editorCoreTextDidChange(_ sender: EditorModuleCore, isDirty: Bool) {
+    document?.markContentDirty(isDirty)
 
     if findPanel.mode != .hidden {
       Task {


### PR DESCRIPTION
For the "Edited" state, we need to save the undo depth every time a document is saved.

When text is changed again, the content is "dirty" when the current undo depth is different from the saved depth.