### PR TITLE
Fix autosave before app termination

### DIFF
--- a/MarkEditMac/Sources/Editor/Controllers/EditorViewController+Menu.swift
+++ b/MarkEditMac/Sources/Editor/Controllers/EditorViewController+Menu.swift
@@ -59,6 +59,15 @@ extension EditorViewController: NSMenuItemValidation {
   }
 }
 
+// MARK: - Application
+
+extension EditorViewController {
+  @IBAction func terminate(_ sender: Any?) {
+    document?.isDying = true
+    NSApplication.shared.terminate(sender)
+  }
+}
+
 // MARK: - Formatting
 
 extension EditorViewController {


### PR DESCRIPTION
```
// The default autosave doesn't work when the app is about to terminate,
// it is because we have to do it in an asynchronous way.
//
// To work around this, check a flag to save the document manually.
```