### PR TITLE
Error autosaving in macOS Sonoma

### DIFF
--- a/MarkEditMac/Sources/Editor/Controllers/EditorViewController+Menu.swift
+++ b/MarkEditMac/Sources/Editor/Controllers/EditorViewController+Menu.swift
@@ -201,6 +201,11 @@ extension EditorViewController {
 // MARK: - Document
 
 private extension EditorViewController {
+  @IBAction func performClose(_ sender: Any?) {
+    document?.isDying = true
+    view.window?.performClose(sender)
+  }
+
   @IBAction func createNewTab(_ sender: Any?) {
     // The easiest way to always create tab regardless of the tabbing mode,
     // just temporarily overwrite the mode to preferred and switch back later.

--- a/MarkEditMac/Sources/Editor/Models/EditorDocument.swift
+++ b/MarkEditMac/Sources/Editor/Models/EditorDocument.swift
@@ -64,6 +64,7 @@ final class EditorDocument: NSDocument {
       windowController.window?.setFrame(autosavedFrame, display: false)
     }
 
+    isDying = false
     hostViewController = contentVC
     hostViewController?.representedObject = self
 
@@ -135,9 +136,9 @@ extension EditorDocument {
       // it is because we have to do it in an asynchronous way.
       //
       // To work around this, check a flag to save the document manually.
-      if isDying, let fileURL, let fileType {
+      if isDying && hasUnautosavedChanges, let fileURL, let fileType {
         try? writeSafely(to: fileURL, ofType: fileType, for: .autosaveAsOperation)
-        return
+        fileModificationDate = .now // Prevent immediate presentedItemDidChange calls
       }
 
       Task {


### PR DESCRIPTION
Closing window also uses `writeSafely`.