### PR TITLE
Upgrade JavaScript libraries

### DIFF
--- a/MarkEditMac/Modules/Sources/Previewer/Resources/katex.html
+++ b/MarkEditMac/Modules/Sources/Previewer/Resources/katex.html
@@ -20,7 +20,7 @@
 <body>
   <div id="container" style="text-align: center;"></div>
   <script type="module" type="text/javascript">
-    import katex from "https://cdn.jsdelivr.net/npm/katex@0.16.4/dist/katex.min.mjs";
+    import katex from "https://cdn.jsdelivr.net/npm/katex@0.16.8/dist/katex.min.mjs";
     const container = document.querySelector("#container");
     container.innerHTML = katex.renderToString("{{DATA}}".code, { throwOnError: false, displayMode: true });
   </script>

--- a/MarkEditMac/Modules/Sources/Previewer/Resources/mermaid.html
+++ b/MarkEditMac/Modules/Sources/Previewer/Resources/mermaid.html
@@ -19,14 +19,14 @@
 <body>
   <div id="container" style="text-align: center;"></div>
   <script type="module">
-    import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@9/dist/mermaid.esm.min.mjs";
+    import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@10.2.4/dist/mermaid.esm.min.mjs";
 
     const isDarkMode = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
     const theme = isDarkMode ? "dark" : "default";
     mermaid.initialize({ theme, startOnLoad: false });
 
     const container = document.querySelector("#container");
-    mermaid.render("graph", "{{DATA}}".code, html => container.innerHTML = html);
+    mermaid.render("graph", "{{DATA}}".code).then(result => container.innerHTML = result.svg);
   </script>
 </body>
 </html>

--- a/MarkEditMac/Modules/Sources/Previewer/Resources/table.html
+++ b/MarkEditMac/Modules/Sources/Previewer/Resources/table.html
@@ -60,7 +60,7 @@
 </head>
 <body>
   <div id="container" style="text-align: center;"></div>
-  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/marked@5.1.1/marked.min.js"></script>
   <script>
     const container = document.querySelector("#container");
     container.innerHTML = marked.parse("{{DATA}}".code);


### PR DESCRIPTION
Upgrade to their latest versions. Also, use strict version numbers to avoid regressions introduced by breaking API changes.

We should upgrade these from time to time, not rely on fuzzy version numbers.