### PR TITLE
Press tab key to accept spellcheck suggestion

### DIFF
--- a/MarkEditMac/Sources/Editor/Controllers/EditorViewController+UI.swift
+++ b/MarkEditMac/Sources/Editor/Controllers/EditorViewController+UI.swift
@@ -29,11 +29,16 @@ extension EditorViewController {
       view.needsLayout = true
     }
 
-    // Press backspace or option to cancel the correction indicator,
-    // it ensures a smoother word completion experience.
     NSEvent.addLocalMonitorForEvents(matching: [.keyDown, .flagsChanged]) { [weak self] event in
+      // Press backspace or option to cancel the correction indicator,
+      // it ensures a smoother word completion experience.
       if (event.keyCode == 51 || event.keyCode == 58), let self {
         NSSpellChecker.shared.declineCorrectionIndicator(for: self.webView)
+      }
+
+      // Press tab key to accept the first spellcheck suggestion
+      if event.keyCode == 48, let self {
+        NSSpellChecker.shared.dismissCorrectionIndicator(for: self.webView)
       }
 
       return event


### PR DESCRIPTION
macOS 1st apps seem to have this behavior by default.