### PR TITLE
Fix string.index crash due to emojis

### DIFF
--- a/MarkEditKit/Sources/Bridge/Native/Modules/EditorModuleCompletion.swift
+++ b/MarkEditKit/Sources/Bridge/Native/Modules/EditorModuleCompletion.swift
@@ -38,7 +38,7 @@ public final class EditorModuleCompletion: NativeModuleCompletion {
     let tokenizer = NLTokenizer(unit: .word)
     tokenizer.string = anchor.text
 
-    let pos = anchor.text.index(anchor.text.startIndex, offsetBy: max(0, anchor.pos - 1))
+    let pos = anchor.text.utf16.index(anchor.text.startIndex, offsetBy: max(0, anchor.pos - 1))
     let range = tokenizer.tokenRange(at: pos)
 
     // Figure out the partial word range with one tokenization pass

--- a/MarkEditKit/Sources/Bridge/Native/Modules/EditorModuleTokenizer.swift
+++ b/MarkEditKit/Sources/Bridge/Native/Modules/EditorModuleTokenizer.swift
@@ -15,7 +15,7 @@ public final class EditorModuleTokenizer: NativeModuleTokenizer {
     let tokenizer = NLTokenizer(unit: .word)
     tokenizer.string = anchor.text
 
-    let pos = anchor.text.index(anchor.text.startIndex, offsetBy: anchor.pos)
+    let pos = anchor.text.utf16.index(anchor.text.startIndex, offsetBy: anchor.pos)
     let bounds = bounds(in: tokenizer.tokenRange(at: pos), text: anchor.text)
 
     // Always select at least one character


### PR DESCRIPTION
Closes https://github.com/MarkEdit-app/MarkEdit/issues/244, also fixes similar problem working with text completions.