### PR TITLE
Re-implement clickable links

### DIFF
--- a/CoreEditor/index.css
+++ b/CoreEditor/index.css
@@ -28,11 +28,6 @@ html, body {
 
 /* Markdown */
 
-.cm-md-link {
-  cursor: pointer;
-  text-decoration: underline;
-}
-
 .cm-md-header:not(.cm-md-frontMatter *) {
   font-weight: bold;
 }

--- a/CoreEditor/src/common/store.ts
+++ b/CoreEditor/src/common/store.ts
@@ -1,4 +1,3 @@
-import { Compartment } from '@codemirror/state';
 import StyleSheets from '../styling/config';
 
 export const editingState = {
@@ -8,4 +7,3 @@ export const editingState = {
 };
 
 export const styleSheets: StyleSheets = {};
-export const clickableLinks: Compartment[] = [];

--- a/CoreEditor/src/styling/markdown.ts
+++ b/CoreEditor/src/styling/markdown.ts
@@ -3,6 +3,7 @@ import { MarkdownConfig } from '@lezer/markdown';
 import { markdownMathExtension as mathExtension } from '../@vendor/joplin/markdownMathParser';
 import { tags } from './builder';
 import { inlineCodeStyle, fencedCodeStyle, previewMermaid, previewMath } from './nodes/code';
+import { linkStyle } from './nodes/link';
 import { previewTable, tableStyle } from './nodes/table';
 import { frontMatterStyle } from './nodes/frontMatter';
 
@@ -29,6 +30,7 @@ export const markdownExtensions: MarkdownConfig[] = [
 export const renderExtensions = [
   inlineCodeStyle,
   fencedCodeStyle,
+  linkStyle,
   tableStyle,
   frontMatterStyle,
 ];

--- a/CoreEditor/src/styling/nodes/link.ts
+++ b/CoreEditor/src/styling/nodes/link.ts
@@ -1,63 +1,76 @@
 import { Decoration, MatchDecorator } from '@codemirror/view';
-import { Compartment } from '@codemirror/state';
-import { clickableLinks as compartments } from '../../common/store';
-import { startEffect, stopEffect } from '../matchers/stateful';
+import { createDecoPlugin } from '../helper';
 
 // Fragile approach, but we only use it for link clicking, it should be fine
 const regexp = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-z]{2,16}\b([-a-zA-Z0-9@:%_+.~#?&//=]*)|(\[.*?\]\()(.+?)\)/g;
 const className = 'cm-md-link';
 
-const matcher = new MatchDecorator({
-  regexp,
-  boundary: /\S/,
-  decorate: (add, from, to, match) => {
-    const deco = Decoration.mark({ class: className });
-    if (match[3]) {
-      // Markdown links, only decorate the part inside parentheses
-      add(from + match[3].length, to - 1, deco);
-    } else {
-      // Normal links, decorate the full match
-      add(from, to, deco);
-    }
-  },
+export const linkStyle = createDecoPlugin(() => {
+  const matcher = new MatchDecorator({
+    regexp,
+    boundary: /\S/,
+    decorate: (add, from, to, match) => {
+      const deco = Decoration.mark({ class: className });
+      if (match[3]) {
+        // Markdown links, only decorate the part inside parentheses
+        add(from + match[3].length, to - 1, deco);
+      } else {
+        // Normal links, decorate the full match
+        add(from, to, deco);
+      }
+    },
+  });
+
+  return matcher.createDeco(window.editor);
 });
 
 export function startClickable() {
-  const compartment = new Compartment;
-  compartments.push(compartment);
-  startEffect(compartment, matcher.createDeco(window.editor));
+  forEachLink(link => {
+    link.style.cursor = 'pointer';
+    link.style.textDecoration = 'underline';
+  });
 }
 
 export function stopClickable() {
-  stopEffect(compartments);
-  compartments.length = 0;
+  forEachLink(link => {
+    link.style.cursor = '';
+    link.style.textDecoration = '';
+  });
 }
 
 export function handleMouseDown(event: MouseEvent) {
-  if (compartments.length > 0 && extractLink(event.target) !== undefined) {
+  if (extractLink(event.target) !== undefined) {
     event.stopPropagation();
     event.preventDefault();
   }
 }
 
 export function handleMouseUp(event: MouseEvent) {
-  if (compartments.length > 0) {
-    const link = extractLink(event.target);
-    if (link !== undefined) {
-      window.open(link, '_blank');
-      stopClickable();
-    }
+  const link = extractLink(event.target);
+  if (link !== undefined) {
+    window.open(link, '_blank');
+    stopClickable();
   }
+}
+
+function forEachLink(handler: (element: HTMLElement) => void) {
+  const links = [...document.querySelectorAll(`.${className}`)] as HTMLElement[];
+  links.forEach(handler);
 }
 
 function extractLink(target: EventTarget | null) {
   const selector = `.${className}`;
   const element = (target as HTMLElement).closest<HTMLElement>(selector);
-  const link = element?.innerText;
+
+  // The link is clickable when it has an underline
+  if (element?.style.textDecoration !== 'underline') {
+    return undefined;
+  }
 
   // It's OK to have a trailing period in a valid url,
   // but generally it's the end of a sentence and we want to remove the period.
-  if (link?.endsWith('.') === true && link.endsWith('..') !== true) {
+  const link = element.innerText;
+  if (link.endsWith('.') === true && link.endsWith('..') !== true) {
     return link.slice(0, -1);
   }
 


### PR DESCRIPTION
We are investigating indented list items, i.e., list items (second line) are aligned to bullets.

Before that, we need to improve the way we make links clickable.

The existing version uses a stateful `Decoration.mark` generation (after rendering process), which splits the parent node into two parts and inherits the tag from the parent. It breaks some convoluted layouts, such as indented list items.

The behavior after this change should remain unchanged.