### PR TITLE
Revert "Re-implement rendering for whitespace before the caret"

### DIFF
--- a/CoreEditor/src/common/store.ts
+++ b/CoreEditor/src/common/store.ts
@@ -4,10 +4,6 @@ export const editingState = {
   isIdle: false,
   hasSelection: false,
   compositionEnded: true,
-
-  // Used for invisible rendering
-  keystrokeTime: 0,
-  invisibleSkippedTime: 0,
 };
 
 export const styleSheets: StyleSheets = {};

--- a/CoreEditor/src/events/index.ts
+++ b/CoreEditor/src/events/index.ts
@@ -15,11 +15,6 @@ export function startObserving() {
   });
 
   document.addEventListener('keydown', event => {
-    // Arrow keys are not considered keystrokes, they don't trigger text change
-    if (!event.key.startsWith('Arrow')) {
-      editingState.keystrokeTime = Date.now();
-    }
-
     if (isMetaKey(event)) {
       link.startClickable();
     } else {

--- a/CoreEditor/src/modules/input/index.ts
+++ b/CoreEditor/src/modules/input/index.ts
@@ -6,8 +6,9 @@ import { setInvisiblesBehavior } from '../config';
 import { startCompletion, isPanelVisible } from '../completion';
 import { isContentDirty } from '../history';
 import { tokenizePosition } from '../tokenizer';
-import { scrollCaretToVisible, scrollToSelection, refreshFocus } from '../../modules/selection';
+import { scrollCaretToVisible, scrollToSelection } from '../../modules/selection';
 import { setShowActiveLineIndicator } from '../../styling/config';
+import { renderWhitespaceBeforeCaret } from '../../styling/nodes/invisible';
 
 import selectedRange from '../selection/selectedRanges';
 import wrapBlock from './wrapBlock';
@@ -81,12 +82,6 @@ export function observeChanges() {
         // CodeMirror doesn't by default fix the offset issue.
         scrollCaretToVisible();
       }
-
-      // Resume the skipped invisible rendering with a delay
-      if (Date.now() - editingState.invisibleSkippedTime < 500) {
-        editingState.keystrokeTime = 0;
-        setTimeout(refreshFocus, 300);
-      }
     }
 
     if (update.selectionSet) {
@@ -108,6 +103,9 @@ export function observeChanges() {
         // it makes the selection easier to read.
         setShowActiveLineIndicator(!hasSelection && window.config.showActiveLineIndicator);
       }
+
+      // Render the special invisible before the main caret
+      renderWhitespaceBeforeCaret();
     }
   });
 }

--- a/CoreEditor/src/modules/selection/index.ts
+++ b/CoreEditor/src/modules/selection/index.ts
@@ -133,13 +133,3 @@ export function scrollPositionToVisible(pos: number) {
     return scrollToSelection('end', margin);
   }
 }
-
-/**
- * Refresh the current focus to force a rendering process.
- */
-export function refreshFocus() {
-  const editor = window.editor;
-  editor.dispatch({
-    selection: editor.state.selection,
-  });
-}

--- a/CoreEditor/src/styling/matchers/stateful.ts
+++ b/CoreEditor/src/styling/matchers/stateful.ts
@@ -1,0 +1,31 @@
+import { Decoration, EditorView } from '@codemirror/view';
+import { Compartment, StateField, StateEffect, RangeSet } from '@codemirror/state';
+
+/**
+ * Start stateful effects with compartment.
+ *
+ * @param compartment Compartment
+ * @param ranges Range set of decorations
+ */
+export function startEffect(compartment: Compartment, ranges: RangeSet<Decoration>) {
+  const extension = StateField.define({
+    create() { return Decoration.none; },
+    update() { return ranges; },
+    provide: field => EditorView.decorations.from(field),
+  });
+
+  const effect = StateEffect.appendConfig.of(compartment.of(extension));
+  window.editor.dispatch({ effects: [effect] });
+}
+
+/**
+ * Stop stateful effects captured in compartments.
+ *
+ * @param compartments Compartments
+ */
+export function stopEffect(compartments: Compartment[]) {
+  for (const compartment of compartments) {
+    const effects = compartment.reconfigure([]);
+    window.editor.dispatch({ effects });
+  }
+}

--- a/CoreEditor/src/styling/nodes/invisible.ts
+++ b/CoreEditor/src/styling/nodes/invisible.ts
@@ -1,13 +1,15 @@
 import { Decoration, highlightTrailingWhitespace } from '@codemirror/view';
+import { Compartment } from '@codemirror/state';
 import { syntaxTree } from '@codemirror/language';
 import { NodeType } from '@lezer/common';
 import { InvisiblesBehavior } from '../../config';
 import { calculateFontSize } from './heading';
 import { createMarkDeco } from '../matchers/regex';
 import { createDecoPlugin } from '../helper';
-import { editingState } from '../../common/store';
 import { selectedTextDecoration } from './selection';
 import { frontMatterRange } from '../../modules/frontMatter';
+import { startEffect, stopEffect } from '../matchers/stateful';
+import { isConnected as isGrammarlyConnected } from '../../modules/grammarly';
 
 // Originally learned from: https://github.com/ChromeDevTools/devtools-frontend/blob/main/front_end/ui/components/text_editor/config.ts
 //
@@ -18,21 +20,54 @@ import { frontMatterRange } from '../../modules/frontMatter';
 // we need to figure out proper font size and set it to the pseudo class.
 const renderInvisibles = createDecoPlugin(() => {
   return createMarkDeco(/\t| +/g, (match, pos) => {
-    const invisible = match[0];
-    const currentTime = Date.now();
-
-    // If we always show invisibles and just inserted a whitespace, we simply skip.
+    // If it's before the main caret and always show invisibles, we simply skip.
     //
     // The reason behind this is that <span> elements created for invisibles can break autocorrect features,
-    // we will resume the skipped rendering in EditorView.updateListener.
-    if (alwaysRenderInvisibles() && invisible === ' ' && (currentTime - editingState.keystrokeTime < 500) && pos === window.editor.state.selection.main.anchor - 1) {
-      editingState.invisibleSkippedTime = currentTime;
+    // see `renderWhitespaceBeforeCaret` regarding how we draw this special whitespace.
+    const invisible = match[0];
+    if (alwaysRenderInvisibles() && invisible === ' ' && pos === window.editor.state.selection.main.anchor - 1) {
       return null;
     }
 
     return getOrCreateDeco(invisible, pos);
   });
 });
+
+// This function renders the space before the main caret "lazily".
+//
+// The reason we need this special rendering logic is that <span> elements can mess up autocorrect features,
+// with some delay can make sure autocorrect work.
+export function renderWhitespaceBeforeCaret() {
+  if (!alwaysRenderInvisibles()) {
+    return;
+  }
+
+  if (storage.lazyCompartment !== undefined) {
+    stopEffect([storage.lazyCompartment]);
+    storage.lazyCompartment = undefined;
+  }
+
+  if (storage.lazyRenderer !== undefined) {
+    clearTimeout(storage.lazyRenderer);
+    storage.lazyRenderer = undefined;
+  }
+
+  storage.lazyRenderer = setTimeout(() => {
+    const editor = window.editor;
+    const doc = editor.state.doc;
+
+    const to = editor.state.selection.main.anchor;
+    const from = to - 1;
+    const spaces = doc.sliceString(from - 1, to + 1);
+
+    // Example valid patterns: " (caret)", "x (caret)", "x (caret)y".
+    if (from >= 0 && doc.sliceString(from, to) === ' ' && (/^[^ ]? $/.test(spaces) || /^[^ ] [^ ]$/.test(spaces))) {
+      const deco = getOrCreateDeco(' ', from);
+      storage.lazyCompartment = new Compartment;
+      startEffect(storage.lazyCompartment, Decoration.set(deco.range(from, to)));
+    }
+  }, 5);
+}
 
 export function invisiblesExtension(behavior: InvisiblesBehavior, hasSelection: boolean) {
   if (behavior === InvisiblesBehavior.always) {
@@ -51,7 +86,8 @@ export function invisiblesExtension(behavior: InvisiblesBehavior, hasSelection: 
 }
 
 function alwaysRenderInvisibles() {
-  return window.config.invisiblesBehavior === InvisiblesBehavior.always;
+  // Rendering whitespace using renderWhitespaceBeforeCaret will stop Grammarly from working
+  return window.config.invisiblesBehavior === InvisiblesBehavior.always && !isGrammarlyConnected();
 }
 
 /**
@@ -106,6 +142,10 @@ function headingLevel(type: NodeType) {
 
 const storage: {
   cachedDecos: Map<string, Decoration>;
+  lazyRenderer: ReturnType<typeof setTimeout> | undefined;
+  lazyCompartment: Compartment | undefined;
 } = {
   cachedDecos: new Map<string, Decoration>(),
+  lazyRenderer: undefined,
+  lazyCompartment: undefined,
 };


### PR DESCRIPTION
Reverts MarkEdit-app/MarkEdit#253, need a better approach.