### PR TITLE
Press ESC to decline the auto correction

### DIFF
--- a/MarkEditMac/Sources/Editor/Controllers/EditorViewController.swift
+++ b/MarkEditMac/Sources/Editor/Controllers/EditorViewController.swift
@@ -183,6 +183,7 @@ final class EditorViewController: NSViewController {
       cancelCompletion()
     }
 
+    NSSpellChecker.shared.declineCorrectionIndicator(for: webView)
     presentedPopover?.close()
   }
 


### PR DESCRIPTION
Reproduce:

- Trigger a spellcheck auto correction
- Press cmd-s to save the doc
- Press the ESC key

The auto correction won't be dismissed.