### PR TITLE
Rephrase tooltip for links

### DIFF
--- a/CoreEditor/index.ts
+++ b/CoreEditor/index.ts
@@ -43,7 +43,7 @@ const config: Config = isProd ? ('{{EDITOR_CONFIG}}' as any) : {
   suggestWhileTyping: false,
   localizable: {
     previewButtonTitle: 'preview',
-    cmdClickToFollowLink: 'Cmd-Click to follow link',
+    cmdClickToOpenLink: '⌘-click to open link',
   },
 };
 

--- a/CoreEditor/src/config.ts
+++ b/CoreEditor/src/config.ts
@@ -15,7 +15,7 @@ export interface Localizable {
   unfoldLine: string;
   // Others
   previewButtonTitle: string;
-  cmdClickToFollowLink: string;
+  cmdClickToOpenLink: string;
 }
 
 /**

--- a/CoreEditor/src/styling/nodes/link.ts
+++ b/CoreEditor/src/styling/nodes/link.ts
@@ -13,7 +13,7 @@ export const linkStyle = createDecoPlugin(() => {
       const deco = Decoration.mark({
         class: className,
         attributes: {
-          title: window.config.localizable?.cmdClickToFollowLink ?? '',
+          title: window.config.localizable?.cmdClickToOpenLink ?? '',
         },
       });
 

--- a/MarkEditCore/Sources/EditorLocalizable.swift
+++ b/MarkEditCore/Sources/EditorLocalizable.swift
@@ -18,7 +18,7 @@ public struct EditorLocalizable: Encodable {
   let foldLine: String
   let unfoldLine: String
   let previewButtonTitle: String
-  let cmdClickToFollowLink: String
+  let cmdClickToOpenLink: String
 
   public init(
     controlCharacter: String,
@@ -29,7 +29,7 @@ public struct EditorLocalizable: Encodable {
     foldLine: String,
     unfoldLine: String,
     previewButtonTitle: String,
-    cmdClickToFollowLink: String
+    cmdClickToOpenLink: String
   ) {
     self.controlCharacter = controlCharacter
     self.foldedLines = foldedLines
@@ -39,6 +39,6 @@ public struct EditorLocalizable: Encodable {
     self.foldLine = foldLine
     self.unfoldLine = unfoldLine
     self.previewButtonTitle = previewButtonTitle
-    self.cmdClickToFollowLink = cmdClickToFollowLink
+    self.cmdClickToOpenLink = cmdClickToOpenLink
   }
 }

--- a/MarkEditMac/Resources/zh-Hans.lproj/Localizable.strings
+++ b/MarkEditMac/Resources/zh-Hans.lproj/Localizable.strings
@@ -1,3 +1,6 @@
+/* Tooltip for links */
+"⌘-click to open link" = "⌘ 点击打开链接";
+
 /* Use 1 tab as the indent unit */
 "1 tab" = "1 个制表符";
 
@@ -42,9 +45,6 @@
 
 /* Menu item: clear recents */
 "Clear Recents" = "清除最近";
-
-/* Tooltip for links */
-"Cmd-Click to follow link" = "Cmd 点击打开链接";
 
 /* Column name for table creation */
 "Column" = "列";

--- a/MarkEditMac/Resources/zh-Hant.lproj/Localizable.strings
+++ b/MarkEditMac/Resources/zh-Hant.lproj/Localizable.strings
@@ -1,3 +1,6 @@
+/* Tooltip for links */
+"⌘-click to open link" = "⌘ 點選開啟連結";
+
 /* Use 1 tab as the indent unit */
 "1 tab" = "1 個制表符";
 
@@ -42,9 +45,6 @@
 
 /* Menu item: clear recents */
 "Clear Recents" = "清除最近";
-
-/* Tooltip for links */
-"Cmd-Click to follow link" = "Cmd 點選開啟連結";
 
 /* Column name for table creation */
 "Column" = "列";

--- a/MarkEditMac/Sources/Main/AppResources.swift
+++ b/MarkEditMac/Sources/Main/AppResources.swift
@@ -36,7 +36,7 @@ enum Localized {
     static let unfoldLine = String(localized: "Unfold Line", comment: "Phrase used in CodeMirror to unfold a line")
     static let defaultLinkTitle = String(localized: "title", comment: "Default title used for link insertion")
     static let previewButtonTitle = String(localized: "preview", comment: "Button title for code preview")
-    static let cmdClickToFollowLink = String(localized: "Cmd-Click to follow link", comment: "Tooltip for links")
+    static let cmdClickToOpenLink = String(localized: "⌘-click to open link", comment: "Tooltip for links")
     static let tableColumnName = String(localized: "Column", comment: "Column name for table creation")
     static let tableItemName = String(localized: "Item", comment: "Item name for table creation")
   }
@@ -203,7 +203,7 @@ extension EditorLocalizable {
       foldLine: Localized.Editor.foldLine,
       unfoldLine: Localized.Editor.unfoldLine,
       previewButtonTitle: Localized.Editor.previewButtonTitle,
-      cmdClickToFollowLink: Localized.Editor.cmdClickToFollowLink
+      cmdClickToOpenLink: Localized.Editor.cmdClickToOpenLink
     )
   }
 }


### PR DESCRIPTION
Instead of saying "follow link", we now use "open link" because it is used more often.