### PR TITLE
Disable font-kerning

### DIFF
--- a/CoreEditor/index.css
+++ b/CoreEditor/index.css
@@ -14,6 +14,9 @@ html, body {
 
 .cm-editor {
   height: 100vh;
+
+  /* selectionMatch doesn't work well with some fonts, such as system-ui, ui-rounded */
+  font-kerning: none;
 }
 
 .cm-gutters {


### PR DESCRIPTION
`selectionMatch` doesn't work well with some fonts, such as `system-ui`, `ui-rounded`.