### PR TITLE
Performance improvements

### DIFF
--- a/CoreEditor/src/bridge/native/core.ts
+++ b/CoreEditor/src/bridge/native/core.ts
@@ -9,6 +9,5 @@ import { LineColumnInfo } from '../../modules/selection/types';
 export interface NativeModuleCore extends NativeModule {
   notifyWindowDidLoad(): void;
   notifyViewportScaleDidChange(): void;
-  notifyTextDidChange({ isDirty }: { isDirty: boolean }): void;
-  notifySelectionDidChange({ lineColumn, contentEdited }: { lineColumn: LineColumnInfo; contentEdited: boolean }): void;
+  notifyViewDidUpdate({ contentEdited, isDirty, selectedLineColumn }: { contentEdited: boolean; isDirty: boolean; selectedLineColumn: LineColumnInfo }): void;
 }

--- a/CoreEditor/src/core.ts
+++ b/CoreEditor/src/core.ts
@@ -75,9 +75,14 @@ export function resetEditor(doc: string) {
   styling.setUp(window.config, themes.loadTheme(window.config.theme).colors);
 
   // After calling editor.focus(), the selection is set to [Ln 1, Col 1]
-  window.nativeModules.core.notifySelectionDidChange({
-    lineColumn: { line: 1 as CodeGen_Int, column: 1 as CodeGen_Int, length: 0 as CodeGen_Int },
+  window.nativeModules.core.notifyViewDidUpdate({
     contentEdited: false,
+    isDirty: false,
+    selectedLineColumn: {
+      line: 1 as CodeGen_Int,
+      column: 1 as CodeGen_Int,
+      length: 0 as CodeGen_Int,
+    },
   });
 
   // Observe viewport scale changes, i.e., pinch to zoom

--- a/CoreEditor/src/events/index.ts
+++ b/CoreEditor/src/events/index.ts
@@ -22,13 +22,13 @@ export function startObserving() {
 
     if (isMetaKey(event)) {
       link.startClickable();
-    } else {
-      link.stopClickable();
     }
   });
 
-  document.addEventListener('keyup', () => {
-    link.stopClickable();
+  document.addEventListener('keyup', event => {
+    if (isMetaKey(event)) {
+      link.stopClickable();
+    }
   });
 
   document.addEventListener('mousedown', event => {

--- a/CoreEditor/src/styling/nodes/link.ts
+++ b/CoreEditor/src/styling/nodes/link.ts
@@ -55,18 +55,17 @@ export function handleMouseUp(event: MouseEvent) {
   const link = extractLink(event.target);
   if (link !== undefined) {
     window.open(link, '_blank');
-    stopClickable();
   }
 }
 
 function forEachLink(handler: (element: HTMLElement) => void) {
-  const links = [...document.querySelectorAll(`.${className}`)] as HTMLElement[];
+  const links = document.querySelectorAll(`.${className}`);
   links.forEach(handler);
 }
 
 function extractLink(target: EventTarget | null) {
   const selector = `.${className}`;
-  const element = (target as HTMLElement).closest<HTMLElement>(selector);
+  const element = (target as HTMLElement | null)?.closest<HTMLElement>(selector);
 
   // The link is clickable when it has an underline
   if (element?.style.textDecoration !== 'underline') {

--- a/MarkEditKit/Sources/Bridge/Native/Modules/EditorModuleCore.swift
+++ b/MarkEditKit/Sources/Bridge/Native/Modules/EditorModuleCore.swift
@@ -9,11 +9,11 @@ import Foundation
 public protocol EditorModuleCoreDelegate: AnyObject {
   func editorCoreWindowDidLoad(_ sender: EditorModuleCore)
   func editorCoreViewportScaleDidChange(_ sender: EditorModuleCore)
-  func editorCoreTextDidChange(_ sender: EditorModuleCore, isDirty: Bool)
-  func editorCore(
+  func editorCoreViewDidUpdate(
     _ sender: EditorModuleCore,
-    selectionDidChange lineColumn: LineColumnInfo,
-    contentEdited: Bool
+    contentEdited: Bool,
+    isDirty: Bool,
+    selectedLineColumn: LineColumnInfo
   )
 }
 
@@ -32,11 +32,16 @@ public final class EditorModuleCore: NativeModuleCore {
     delegate?.editorCoreViewportScaleDidChange(self)
   }
 
-  public func notifyTextDidChange(isDirty: Bool) {
-    delegate?.editorCoreTextDidChange(self, isDirty: isDirty)
-  }
-
-  public func notifySelectionDidChange(lineColumn: LineColumnInfo, contentEdited: Bool) {
-    delegate?.editorCore(self, selectionDidChange: lineColumn, contentEdited: contentEdited)
+  public func notifyViewDidUpdate(
+    contentEdited: Bool,
+    isDirty: Bool,
+    selectedLineColumn: LineColumnInfo
+  ) {
+    delegate?.editorCoreViewDidUpdate(
+      self,
+      contentEdited: contentEdited,
+      isDirty: isDirty,
+      selectedLineColumn: selectedLineColumn
+    )
   }
 }

--- a/MarkEditMac/Sources/Editor/Controllers/EditorViewController+Delegate.swift
+++ b/MarkEditMac/Sources/Editor/Controllers/EditorViewController+Delegate.swift
@@ -70,27 +70,26 @@ extension EditorViewController: EditorModuleCoreDelegate {
     cancelOperation(sender)
   }
 
-  func editorCoreTextDidChange(_ sender: EditorModuleCore, isDirty: Bool) {
-    document?.markContentDirty(isDirty)
-
-    if findPanel.mode != .hidden {
-      Task {
-        if let count = try? await bridge.search.numberOfMatches() {
-          updateTextFinderPanels(numberOfItems: count)
-        }
-      }
-    }
-  }
-
-  func editorCore(
+  func editorCoreViewDidUpdate(
     _ sender: EditorModuleCore,
-    selectionDidChange lineColumn: LineColumnInfo,
-    contentEdited: Bool
+    contentEdited: Bool,
+    isDirty: Bool,
+    selectedLineColumn: LineColumnInfo
   ) {
-    statusView.updateLineColumn(lineColumn)
+    statusView.updateLineColumn(selectedLineColumn)
     layoutStatusView()
 
-    if !contentEdited {
+    if contentEdited {
+      document?.markContentDirty(isDirty)
+
+      if findPanel.mode != .hidden {
+        Task {
+          if let count = try? await bridge.search.numberOfMatches() {
+            updateTextFinderPanels(numberOfItems: count)
+          }
+        }
+      }
+    } else {
       cancelCompletion()
     }
   }


### PR DESCRIPTION
This PR makes the below performance improvements:

- Reduce unnecessary updates of clickable links
- Remove unnecessary spreading in `forEachLink`
- Merge `notifyTextDidChange` and `notifySelectionDidChange` to `notifyViewDidUpdate`
- Debounce `notifyViewDidUpdate`