### PR TITLE
Move frontMatter style to line decos

### DIFF
--- a/CoreEditor/src/styling/helper.ts
+++ b/CoreEditor/src/styling/helper.ts
@@ -1,5 +1,5 @@
 import { Decoration, DOMEventHandlers, EditorView, ViewPlugin } from '@codemirror/view';
-import { RangeSet } from '@codemirror/state';
+import { Range, RangeSet } from '@codemirror/state';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function createDecoPlugin(builder: () => RangeSet<Decoration>, eventHandlers?: DOMEventHandlers<any>) {
@@ -10,6 +10,25 @@ export function createDecoPlugin(builder: () => RangeSet<Decoration>, eventHandl
     }),
     eventHandlers,
   });
+}
+
+/**
+ * Get line deco ranges for a text range, which can be multiple lines.
+ */
+export function lineDecoRanges(from: number, to: number, className: string) {
+  const doc = window.editor.state.doc;
+  const decos: Range<Decoration>[] = [];
+  const start = doc.lineAt(from).number;
+  const end = doc.lineAt(to).number;
+
+  // Generate the range for each line
+  for (let index = start; index <= end; ++index) {
+    const line = doc.line(index);
+    const deco = Decoration.line({ class: className });
+    decos.push(deco.range(line.from, line.from));
+  }
+
+  return decos;
 }
 
 export function updateStyleSheet(element: HTMLStyleElement | null, update: (style: CSSStyleDeclaration, rule: CSSStyleRule) => void) {

--- a/CoreEditor/src/styling/matchers/lezer.ts
+++ b/CoreEditor/src/styling/matchers/lezer.ts
@@ -3,6 +3,7 @@ import { Range } from '@codemirror/state';
 import { syntaxTree } from '@codemirror/language';
 import { SyntaxNodeRef } from '@lezer/common';
 import { WidgetView } from '../../views/types';
+import { lineDecoRanges } from '../helper';
 
 /**
  * Create mark decorations.
@@ -40,21 +41,7 @@ export function createWidgetDeco(nodeName: string | string[], builder: (node: Sy
  * @param className Class to decorate the node
  */
 export function createLineDeco(nodeName: string | string[], className: string) {
-  return createDecos(nodeName, node => {
-    const doc = window.editor.state.doc;
-    const decos: Range<Decoration>[] = [];
-    const start = doc.lineAt(node.from).number;
-    const end = doc.lineAt(node.to).number;
-
-    // Generate deco for each line
-    for (let index = start; index <= end; ++index) {
-      const line = doc.line(index);
-      const deco = Decoration.line({ class: className });
-      decos.push(deco.range(line.from, line.from));
-    }
-
-    return decos;
-  });
+  return createDecos(nodeName, node => lineDecoRanges(node.from, node.to, className));
 }
 
 /**

--- a/CoreEditor/src/styling/nodes/frontMatter.ts
+++ b/CoreEditor/src/styling/nodes/frontMatter.ts
@@ -1,5 +1,5 @@
 import { Decoration } from '@codemirror/view';
-import { createDecoPlugin } from '../helper';
+import { createDecoPlugin, lineDecoRanges } from '../helper';
 import { frontMatterRange } from '../../modules/frontMatter';
 
 /**
@@ -13,6 +13,5 @@ export const frontMatterStyle = createDecoPlugin(() => {
 
   // We don't have a cm6 parser for yaml just yet,
   // let's simply decorate the front matter section with a class.
-  const deco = Decoration.mark({ class: 'cm-md-frontMatter' }).range(range.from, range.to);
-  return Decoration.set(deco);
+  return Decoration.set(lineDecoRanges(range.from, range.to, 'cm-md-frontMatter'));
 });


### PR DESCRIPTION
Styles that uses line decos: code block, table, frontMatter.