### PR TITLE
Skip doc saving in viewing mode

### DIFF
--- a/MarkEditMac/Sources/Editor/Models/EditorDocument.swift
+++ b/MarkEditMac/Sources/Editor/Models/EditorDocument.swift
@@ -241,6 +241,11 @@ private extension EditorDocument {
   }
 
   func saveAsynchronously(saveAction: () -> Void) async {
+    // In viewing mode (aka version browsing), saveAction is directly skipped
+    guard !isInViewingMode else {
+      return
+    }
+
     let insertFinalNewline = AppPreferences.Assistant.insertFinalNewline
     let trimTrailingWhitespace = AppPreferences.Assistant.trimTrailingWhitespace
 


### PR DESCRIPTION
Not only because it changes the content, but also it makes the window harder to close...