### PR TITLE
Minimize extensions in read-only mode

### DIFF
--- a/CoreEditor/src/extensions.ts
+++ b/CoreEditor/src/extensions.ts
@@ -131,6 +131,8 @@ function fullExtensions(options: { lineBreak?: string }) {
 
 /**
  * The minimum set of extensions used in read-only mode.
+ *
+ * Don't share the code with @light builds, which increase the bundle size.
  */
 function readOnlyExtensions() {
   return [


### PR DESCRIPTION
Don't share with the preview extension, which makes the extension bigger.