### PR TITLE
Improve handleMouseMoved for multi-window scenario

### DIFF
--- a/MarkEditMac/Sources/Editor/Controllers/EditorViewController+UI.swift
+++ b/MarkEditMac/Sources/Editor/Controllers/EditorViewController+UI.swift
@@ -128,6 +128,10 @@ extension EditorViewController {
   }
 
   func handleMouseMoved(_ event: NSEvent) {
+    guard view.window?.isMainWindow == true else {
+      return
+    }
+
     // WKWebView contentEditable keeps showing i-beam, fix that
     if NSCursor.current != NSCursor.arrow {
       let location = event.locationInWindow.y


### PR DESCRIPTION
It is unnecessary to update for non-main windows, the browser also skips updating it.