### PR TITLE
Fix keyboard navigation for find panels

### DIFF
--- a/MarkEditMac/Sources/Editor/Controllers/EditorViewController+Delegate.swift
+++ b/MarkEditMac/Sources/Editor/Controllers/EditorViewController+Delegate.swift
@@ -169,8 +169,12 @@ extension EditorViewController: EditorFindPanelDelegate {
     updateTextFinderQuery()
   }
 
-  func editorFindPanelDidPressTabKey(_ sender: EditorFindPanel) {
-    replacePanel.textField.startEditing(in: view.window)
+  func editorFindPanelDidPressTabKey(_ sender: EditorFindPanel, isBacktab: Bool) {
+    if isBacktab {
+      view.window?.makeFirstResponder(webView)
+    } else {
+      replacePanel.textField.startEditing(in: view.window)
+    }
   }
 
   func editorFindPanelDidClickNext(_ sender: EditorFindPanel) {
@@ -187,6 +191,14 @@ extension EditorViewController: EditorFindPanelDelegate {
 extension EditorViewController: EditorReplacePanelDelegate {
   func editorReplacePanel(_ sender: EditorReplacePanel, replacementDidChange replacement: String) {
     updateTextFinderQuery()
+  }
+
+  func editorReplacePanelDidPressTabKey(_ sender: EditorReplacePanel, isBacktab: Bool) {
+    if isBacktab {
+      findPanel.searchField.startEditing(in: view.window)
+    } else {
+      view.window?.makeFirstResponder(webView)
+    }
   }
 
   func editorReplacePanelDidClickReplaceNext(_ sender: EditorReplacePanel) {

--- a/MarkEditMac/Sources/Panels/Find/EditorFindPanel+Delegate.swift
+++ b/MarkEditMac/Sources/Panels/Find/EditorFindPanel+Delegate.swift
@@ -14,7 +14,10 @@ extension EditorFindPanel: NSSearchFieldDelegate {
     switch (selector, mode) {
     case (#selector(insertTab(_:)), .replace):
       // Focus on the replace panel
-      delegate?.editorFindPanelDidPressTabKey(self)
+      delegate?.editorFindPanelDidPressTabKey(self, isBacktab: false)
+      return true
+    case (#selector(insertBacktab(_:)), _):
+      delegate?.editorFindPanelDidPressTabKey(self, isBacktab: true)
       return true
     case (#selector(insertNewline(_:)), _):
       // Navigate between search results

--- a/MarkEditMac/Sources/Panels/Find/EditorFindPanel.swift
+++ b/MarkEditMac/Sources/Panels/Find/EditorFindPanel.swift
@@ -21,7 +21,7 @@ protocol EditorFindPanelDelegate: AnyObject {
   func editorFindPanel(_ sender: EditorFindPanel, modeDidChange mode: EditorFindMode)
   func editorFindPanel(_ sender: EditorFindPanel, searchTermDidChange searchTerm: String)
   func editorFindPanelDidChangeOptions(_ sender: EditorFindPanel)
-  func editorFindPanelDidPressTabKey(_ sender: EditorFindPanel)
+  func editorFindPanelDidPressTabKey(_ sender: EditorFindPanel, isBacktab: Bool)
   func editorFindPanelDidClickNext(_ sender: EditorFindPanel)
   func editorFindPanelDidClickPrevious(_ sender: EditorFindPanel)
 }

--- a/MarkEditMac/Sources/Panels/Replace/EditorReplacePanel.swift
+++ b/MarkEditMac/Sources/Panels/Replace/EditorReplacePanel.swift
@@ -9,6 +9,7 @@ import AppKit
 
 protocol EditorReplacePanelDelegate: AnyObject {
   func editorReplacePanel(_ sender: EditorReplacePanel, replacementDidChange replacement: String)
+  func editorReplacePanelDidPressTabKey(_ sender: EditorReplacePanel, isBacktab: Bool)
   func editorReplacePanelDidClickReplaceNext(_ sender: EditorReplacePanel)
   func editorReplacePanelDidClickReplaceAll(_ sender: EditorReplacePanel)
 }
@@ -88,6 +89,12 @@ extension EditorReplacePanel: NSTextFieldDelegate {
 
   func control(_ control: NSControl, textView: NSTextView, doCommandBy selector: Selector) -> Bool {
     switch (selector, replaceButtons.isEnabled) {
+    case (#selector(insertTab(_:)), _):
+      delegate?.editorReplacePanelDidPressTabKey(self, isBacktab: false)
+      return true
+    case (#selector(insertBacktab(_:)), _):
+      delegate?.editorReplacePanelDidPressTabKey(self, isBacktab: true)
+      return true
     case (#selector(insertNewline(_:)), true):
       delegate?.editorReplacePanelDidClickReplaceNext(self)
       return true


### PR DESCRIPTION
We need this because replacePanel is added before findPanel, in order to have nicer animations.

There might be a better way to achieve this though.