### PR TITLE
Fix search behaviors

### DIFF
--- a/CoreEditor/src/bridge/web/search.ts
+++ b/CoreEditor/src/bridge/web/search.ts
@@ -19,8 +19,8 @@ import {
 export interface WebModuleSearch extends WebModule {
   setState({ enabled }: { enabled: boolean }): void;
   updateQuery({ options }: { options: SearchOptions }): CodeGen_Int;
-  findNext(): void;
-  findPrevious(): void;
+  findNext({ search }: { search: string }): void;
+  findPrevious({ search }: { search: string }): void;
   replaceNext(): void;
   replaceAll(): void;
   selectAllOccurrences(): void;
@@ -36,12 +36,12 @@ export class WebModuleSearchImpl implements WebModuleSearch {
     return updateQuery(options) as CodeGen_Int;
   }
 
-  findNext(): void {
-    findNext();
+  findNext({ search }: { search: string }): void {
+    findNext(search);
   }
 
-  findPrevious(): void {
-    findPrevious();
+  findPrevious({ search }: { search: string }): void {
+    findPrevious(search);
   }
 
   replaceNext(): void {

--- a/CoreEditor/src/modules/search/index.ts
+++ b/CoreEditor/src/modules/search/index.ts
@@ -11,32 +11,49 @@ import selectWithRanges from '../selection/selectWithRanges';
 import * as search from '@codemirror/search';
 
 export function setState(enabled: boolean) {
+  if (storage.isEnabled === enabled) {
+    return;
+  }
+
   if (enabled) {
     openSearchPanel(window.editor);
   } else {
     closeSearchPanel(window.editor);
   }
+
+  storage.isEnabled = enabled;
 }
 
 export function updateQuery(options: SearchOptions): number {
+  storage.options = options;
+  setState(true);
+
   const editor = window.editor;
-  const selectMatch = () => findNext() || findPrevious();
+  const selectMatch = () => {
+    if (!options.refocus) {
+      return;
+    }
+
+    return findNext(options.search) || findPrevious(options.search);
+  };
 
   const query = new SearchQuery(options);
   editor.dispatch({ effects: setSearchQuery.of(query) });
 
   const ranges = rangesFromQuery(query);
   if (ranges !== undefined) {
-    for (const range of ranges) {
-      // If there's a visible range, focus on it
-      const rect = editor.coordsAtPos(range.from);
-      if (rect !== null && rect.top >= 0 && rect.top <= editor.dom.clientHeight) {
-        editor.dispatch({
-          selection: EditorSelection.range(range.from, range.to),
-        });
+    // If refocus is enabled and there's a visible range, focus on it
+    if (options.refocus) {
+      for (const range of ranges) {
+        const rect = editor.coordsAtPos(range.from);
+        if (rect !== null && rect.top >= 0 && rect.top <= editor.dom.clientHeight) {
+          editor.dispatch({
+            selection: EditorSelection.range(range.from, range.to),
+          });
 
-        scrollSearchMatchToVisible();
-        return ranges.length;
+          scrollSearchMatchToVisible();
+          return ranges.length;
+        }
       }
     }
 
@@ -48,14 +65,18 @@ export function updateQuery(options: SearchOptions): number {
   return document.querySelectorAll('.cm-searchMatch').length;
 }
 
-export function findNext() {
+export function findNext(term: string) {
+  prepareNavigation(term);
   const result = search.findNext(window.editor);
+
   scrollSearchMatchToVisible();
   return result;
 }
 
-export function findPrevious() {
+export function findPrevious(term: string) {
+  prepareNavigation(term);
   const result = search.findPrevious(window.editor);
+
   scrollSearchMatchToVisible();
   return result;
 }
@@ -85,3 +106,23 @@ export function numberOfMatches(): CodeGen_Int {
 }
 
 export type { SearchOptions };
+
+function prepareNavigation(search: string) {
+  if (storage.options === undefined) {
+    return;
+  }
+
+  setState(true);
+  storage.options.search = search;
+
+  const query = new SearchQuery(storage.options);
+  window.editor.dispatch({ effects: setSearchQuery.of(query) });
+}
+
+const storage: {
+  isEnabled: boolean;
+  options: SearchOptions | undefined;
+} = {
+  isEnabled: false,
+  options: undefined,
+};

--- a/CoreEditor/src/modules/search/options.ts
+++ b/CoreEditor/src/modules/search/options.ts
@@ -4,5 +4,6 @@ export default interface SearchOptions {
   literal: boolean;
   regexp: boolean;
   wholeWord: boolean;
+  refocus: boolean;
   replace?: string;
 }

--- a/MarkEditKit/Sources/Bridge/Web/Generated/WebBridgeSearch.swift
+++ b/MarkEditKit/Sources/Bridge/Web/Generated/WebBridgeSearch.swift
@@ -46,12 +46,28 @@ public final class WebBridgeSearch {
     }
   }
 
-  public func findNext(completion: ((Result<Void, WKWebView.InvokeError>) -> Void)? = nil) {
-    webView?.invoke(path: "webModules.search.findNext", completion: completion)
+  public func findNext(search: String, completion: ((Result<Void, WKWebView.InvokeError>) -> Void)? = nil) {
+    struct Message: Encodable {
+      let search: String
+    }
+
+    let message = Message(
+      search: search
+    )
+
+    webView?.invoke(path: "webModules.search.findNext", message: message, completion: completion)
   }
 
-  public func findPrevious(completion: ((Result<Void, WKWebView.InvokeError>) -> Void)? = nil) {
-    webView?.invoke(path: "webModules.search.findPrevious", completion: completion)
+  public func findPrevious(search: String, completion: ((Result<Void, WKWebView.InvokeError>) -> Void)? = nil) {
+    struct Message: Encodable {
+      let search: String
+    }
+
+    let message = Message(
+      search: search
+    )
+
+    webView?.invoke(path: "webModules.search.findPrevious", message: message, completion: completion)
   }
 
   public func replaceNext(completion: ((Result<Void, WKWebView.InvokeError>) -> Void)? = nil) {
@@ -82,14 +98,16 @@ public struct SearchOptions: Codable {
   public var literal: Bool
   public var regexp: Bool
   public var wholeWord: Bool
+  public var refocus: Bool
   public var replace: String?
 
-  public init(search: String, caseSensitive: Bool, literal: Bool, regexp: Bool, wholeWord: Bool, replace: String?) {
+  public init(search: String, caseSensitive: Bool, literal: Bool, regexp: Bool, wholeWord: Bool, refocus: Bool, replace: String?) {
     self.search = search
     self.caseSensitive = caseSensitive
     self.literal = literal
     self.regexp = regexp
     self.wholeWord = wholeWord
+    self.refocus = refocus
     self.replace = replace
   }
 }


### PR DESCRIPTION
CodeMirror's `openSearchPanel` uses the selection to perform search, make this change to improve the behavior of `cmd-f` and `cmd-e`:

Moving most states changing logic to search operations, opening the panel would not perform the search, hiding the panel would set the state to false.