### PR TITLE
Fix inaccurate selection status of emojis

### DIFF
--- a/CoreEditor/src/core.ts
+++ b/CoreEditor/src/core.ts
@@ -96,9 +96,9 @@ export function resetEditor(
     contentEdited: false,
     isDirty: false,
     selectedLineColumn: {
-      line: 1 as CodeGen_Int,
-      column: 1 as CodeGen_Int,
-      length: 0 as CodeGen_Int,
+      lineNumber: 1 as CodeGen_Int,
+      columnText: '',
+      selectionText: '',
     },
   });
 

--- a/CoreEditor/src/modules/selection/selectedLineColumn.ts
+++ b/CoreEditor/src/modules/selection/selectedLineColumn.ts
@@ -6,13 +6,12 @@ import { LineColumnInfo } from './types';
 export function selectedLineColumn(): LineColumnInfo {
   const editor = window.editor;
   const state = editor.state;
-  const selection = editor.state.selection.main;
+  const selection = state.selection.main;
   const line = state.doc.lineAt(selection.head);
-  const column = selection.head - line.from + 1;
 
   return {
-    line: line.number as CodeGen_Int,
-    column: column as CodeGen_Int,
-    length: (selection.to - selection.from) as CodeGen_Int,
+    lineNumber: line.number as CodeGen_Int,
+    columnText: state.sliceDoc(line.from, selection.head),
+    selectionText: state.sliceDoc(selection.from, selection.to),
   };
 }

--- a/CoreEditor/src/modules/selection/types.ts
+++ b/CoreEditor/src/modules/selection/types.ts
@@ -1,5 +1,5 @@
 export interface LineColumnInfo {
-  line: CodeGen_Int;
-  column: CodeGen_Int;
-  length: CodeGen_Int;
+  lineNumber: CodeGen_Int;
+  columnText: string;
+  selectionText: string;
 }

--- a/MarkEditKit/Sources/Bridge/Native/Generated/NativeModuleCore.swift
+++ b/MarkEditKit/Sources/Bridge/Native/Generated/NativeModuleCore.swift
@@ -72,13 +72,13 @@ final class NativeBridgeCore: NativeBridge {
 }
 
 public struct LineColumnInfo: Decodable, Equatable {
-  public var line: Int
-  public var column: Int
-  public var length: Int
+  public var lineNumber: Int
+  public var columnText: String
+  public var selectionText: String
 
-  public init(line: Int, column: Int, length: Int) {
-    self.line = line
-    self.column = column
-    self.length = length
+  public init(lineNumber: Int, columnText: String, selectionText: String) {
+    self.lineNumber = lineNumber
+    self.columnText = columnText
+    self.selectionText = selectionText
   }
 }

--- a/MarkEditMac/Sources/Editor/Views/EditorStatusView.swift
+++ b/MarkEditMac/Sources/Editor/Views/EditorStatusView.swift
@@ -43,11 +43,11 @@ final class EditorStatusView: NSView, BackgroundTheming {
   func updateLineColumn(_ info: LineColumnInfo) {
     let title = {
       // Don't localize the labels
-      let lineColumn = "Ln \(info.line), Col \(info.column)"
-      if info.length > 0 {
-        return "\(lineColumn) (\(info.length))"
-      } else {
+      let lineColumn = "Ln \(info.lineNumber), Col \(info.columnText.count + 1)"
+      if info.selectionText.isEmpty {
         return lineColumn
+      } else {
+        return "\(lineColumn) (\(info.selectionText.count))"
       }
     }()
 


### PR DESCRIPTION
JavaScript can't handle unicode strings correctly, we should pass it to the native and let Swift handle these strings.