### PR TITLE
Prefer state.sliceDoc over state.doc.sliceString

### DIFF
--- a/CoreEditor/src/modules/commands/toggleBlockWithMarks.ts
+++ b/CoreEditor/src/modules/commands/toggleBlockWithMarks.ts
@@ -8,13 +8,13 @@ import { EditorSelection } from '@codemirror/state';
  */
 export default function toggleBlockWithMarks(leftMark: string, rightMark: string) {
   const editor = window.editor;
-  const doc = editor.state.doc;
+  const state = editor.state;
 
   // Take care of all updates and merge them into a single one
   const updates = editor.state.changeByRange(({ from, to }) => {
     const startPos = from;
     const endPos = to;
-    const selectedText = doc.sliceString(from, to);
+    const selectedText = state.sliceDoc(from, to);
 
     const startTestPos = startPos - leftMark.length;
     const endTestPos = endPos + rightMark.length;
@@ -22,9 +22,9 @@ export default function toggleBlockWithMarks(leftMark: string, rightMark: string
     let matched = false;
     let newPos = 0;
 
-    if (startTestPos >= 0 && endTestPos <= doc.length) {
-      const leftTest = doc.sliceString(startTestPos, startTestPos + leftMark.length);
-      const rightTest = doc.sliceString(endTestPos - rightMark.length, endTestPos);
+    if (startTestPos >= 0 && endTestPos <= state.doc.length) {
+      const leftTest = state.sliceDoc(startTestPos, startTestPos + leftMark.length);
+      const rightTest = state.sliceDoc(endTestPos - rightMark.length, endTestPos);
       matched = leftTest === leftMark && rightTest === rightMark;
     }
 

--- a/CoreEditor/src/modules/frontMatter/index.ts
+++ b/CoreEditor/src/modules/frontMatter/index.ts
@@ -5,15 +5,15 @@ import { load as loadYaml } from 'js-yaml';
  */
 export function frontMatterRange() {
   const editor = window.editor;
-  const doc = editor.state.doc;
+  const state = editor.state;
 
   // Fail fast, it's not possible to be front matter
-  if (doc.sliceString(0, 3) !== '---') {
+  if (state.sliceDoc(0, 3) !== '---') {
     return undefined;
   }
 
   // Definition: https://jekyllrb.com/docs/front-matter/
-  const match = /^---\n(.+?)\n---/s.exec(doc.toString());
+  const match = /^---\n(.+?)\n---/s.exec(state.doc.toString());
   if (match && isYaml(match[1])) {
     return { from: 0, to: match[0].length };
   }

--- a/CoreEditor/src/modules/input/wrapBlock.ts
+++ b/CoreEditor/src/modules/input/wrapBlock.ts
@@ -12,9 +12,9 @@ export default function wrapBlock(mark: string, editor: EditorView) {
     return false;
   }
 
-  const doc = editor.state.doc;
+  const state = editor.state;
   editor.dispatch(editor.state.changeByRange(({ from, to }) => {
-    const selection = doc.sliceString(from, to);
+    const selection = state.sliceDoc(from, to);
     const replacement = from === to ? mark : `${mark}${selection}${mark}`;
     const newPos = from + mark.length;
     return {

--- a/CoreEditor/src/modules/selection/index.ts
+++ b/CoreEditor/src/modules/selection/index.ts
@@ -50,7 +50,7 @@ export function linesWithRange(from: number, to: number) {
 export function selectedMainText(): string {
   const state = window.editor.state;
   const { from, to } = state.selection.main;
-  return state.doc.sliceString(from, to);
+  return state.sliceDoc(from, to);
 }
 
 /**

--- a/CoreEditor/src/modules/toc/index.ts
+++ b/CoreEditor/src/modules/toc/index.ts
@@ -63,7 +63,7 @@ export function getTableOfContents() {
 
       // ATXHeading can have up to 3 leading spaces and arbitrary number of spaces between # and visible characters,
       // example of a valid section header: "   #  Hello"
-      const title = state.doc.sliceString(node.from, node.to).replace(/ {0,3}#+ +/, '');
+      const title = state.sliceDoc(node.from, node.to).replace(/ {0,3}#+ +/, '');
       const level = parseInt(match[1]);
 
       results.push({

--- a/CoreEditor/src/modules/tokenizer/index.ts
+++ b/CoreEditor/src/modules/tokenizer/index.ts
@@ -99,6 +99,6 @@ export function tokenizePosition(event: MouseEvent) {
  */
 function useBuiltIn(pos: number) {
   // We don't care about ascii characters, tokenization is more meaningful for languages like Chinese and Japanese.
-  const character = window.editor.state.doc.sliceString(pos, pos + 1);
+  const character = window.editor.state.sliceDoc(pos, pos + 1);
   return /[ -~]/.test(character);
 }

--- a/CoreEditor/src/styling/nodes/code.ts
+++ b/CoreEditor/src/styling/nodes/code.ts
@@ -23,7 +23,7 @@ export const codeBlockStyle = createDecoPlugin(() => {
 export const previewMermaid = createDecoPlugin(() => {
   return createWidgetDeco('CodeInfo', node => {
     const state = window.editor.state;
-    if (state.doc.sliceString(node.from, node.to) !== 'mermaid') {
+    if (state.sliceDoc(node.from, node.to) !== 'mermaid') {
       return null;
     }
 
@@ -37,7 +37,7 @@ export const previewMermaid = createDecoPlugin(() => {
       return null;
     }
 
-    const code = state.doc.sliceString(node.to + 1, boundary.from);
+    const code = state.sliceDoc(node.to + 1, boundary.from);
     if (code.trim().length === 0) {
       return null;
     }
@@ -53,7 +53,7 @@ export const previewMermaid = createDecoPlugin(() => {
 export const previewMath = createDecoPlugin(() => {
   return createWidgetDeco('BlockMath', node => {
     const state = window.editor.state;
-    const code = state.doc.sliceString(node.from + 2, node.to - 2); // 2 is the length of "$$"
+    const code = state.sliceDoc(node.from + 2, node.to - 2); // 2 is the length of "$$"
     if (code.trim().length === 0) {
       return null;
     }

--- a/CoreEditor/src/styling/nodes/table.ts
+++ b/CoreEditor/src/styling/nodes/table.ts
@@ -21,7 +21,7 @@ export const previewTable = createDecoPlugin(() => {
     }
 
     const state = window.editor.state;
-    const code = state.doc.sliceString(node.from, node.to);
+    const code = state.sliceDoc(node.from, node.to);
     return new PreviewWidget(code, PreviewType.table, header.to);
   });
 }, { mouseup: showPreview });


### PR DESCRIPTION
Not only for a shorter syntax, `sliceDoc` uses `state.lineBreak`, whereas `sliceString` uses `\n`.