### PR TITLE
[macOS 14] +enableWindowReuse crash

### DIFF
--- a/MarkEditMac/Sources/Editor/Controllers/EditorViewController+Menu.swift
+++ b/MarkEditMac/Sources/Editor/Controllers/EditorViewController+Menu.swift
@@ -16,6 +16,16 @@ extension EditorViewController: NSMenuDelegate {
   func menuNeedsUpdate(_ menu: NSMenu) {
     updateToolbarItemMenus(menu)
   }
+
+  func menuWillOpen(_ menu: NSMenu) {
+    presentedMenu = menu
+  }
+
+  func menuDidClose(_ menu: NSMenu) {
+    DispatchQueue.main.async {
+      self.presentedMenu = nil
+    }
+  }
 }
 
 // MARK: - NSMenuItemValidation
@@ -294,7 +304,14 @@ private extension EditorViewController {
   }
 
   @IBAction func openTableOfContents(_ sender: Any?) {
-    showTableOfContentsMenu()
+    if let presentedMenu {
+      return presentedMenu.cancelTracking()
+    }
+
+    // [macOS 14] +enableWindowReuse crash, DispatchQueue would not work
+    RunLoop.main.perform {
+      self.showTableOfContentsMenu()
+    }
   }
 
   @IBAction func selectPreviousSection(_ sender: Any?) {

--- a/MarkEditMac/Sources/Editor/Controllers/EditorViewController.swift
+++ b/MarkEditMac/Sources/Editor/Controllers/EditorViewController.swift
@@ -17,6 +17,8 @@ final class EditorViewController: NSViewController {
   var hasUnfinishedAnimations = false
   var mouseExitedWindow = false
   var safeAreaObservation: NSKeyValueObservation?
+
+  weak var presentedMenu: NSMenu?
   weak var presentedPopover: NSPopover?
 
   var editorText: String? {


### PR DESCRIPTION
Presenting an NSMenu twice would lead to crashes on macOS Sonoma.