### PR TITLE
Reduce text flickers when resizing the window

### DIFF
--- a/CoreEditor/src/core.ts
+++ b/CoreEditor/src/core.ts
@@ -106,6 +106,10 @@ export function resetEditor(
 
   // Observe viewport scale changes, i.e., pinch to zoom
   window.visualViewport?.addEventListener('resize', () => {
+    // Work around a WebKit bug, text jiggles back and forth when resizing the window
+    editor.requestMeasure();
+
+    // Update native views after viewport scale is changed
     const viewportScale = getViewportScale();
     if (Math.abs(viewportScale - storage.viewportScale) > 0.001) {
       window.nativeModules.core.notifyViewportScaleDidChange();


### PR DESCRIPTION
Once again, a WebKit only bug.