### PR TITLE
Fix CI hangs on Xcode 15

### DIFF
--- a/CoreEditor/test/build.test.ts
+++ b/CoreEditor/test/build.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from '@jest/globals';
+import fs from 'fs';
+import path from 'path';
+
+describe('Build system test suite', () => {
+  test('test existence of editor config', () => {
+    const testFileName = (fileName: string) => {
+      const html = fs.readFileSync(path.join(__dirname, fileName), 'utf-8');
+      expect(html).toContain('"{{EDITOR_CONFIG}}"');
+    };
+
+    testFileName('../dist/index.html');
+    testFileName('../src/@light/dist/index.html');
+  });
+});

--- a/MarkEditMacTests/BundleTests.swift
+++ b/MarkEditMacTests/BundleTests.swift
@@ -11,17 +11,4 @@ final class BundleTests: XCTestCase {
   func testExistenceOfAppIcon() {
     XCTAssertNotNil(NSImage(named: "AppIcon"), "Missing AppIcon from the main bundle")
   }
-
-  func testExistenceOfEditorConfig() {
-    guard let path = Bundle.main.url(forResource: "index", withExtension: "html") else {
-      return XCTAssert(false, "Missing index.html")
-    }
-
-    guard let data = try? Data(contentsOf: path) else {
-      return XCTAssert(false, "Failed to read index.html")
-    }
-
-    let html = String(data: data, encoding: .utf8)
-    XCTAssertEqual(html?.contains("\"{{EDITOR_CONFIG}}\""), true, "Invalid index.html file")
-  }
 }


### PR DESCRIPTION
Trying to figure out why ci hangs after the #356 change.

Update: no idea, but seems `testExistenceOfEditorConfig` was the root cause.