### PR TITLE
Fix new window creation for external links

### DIFF
--- a/MarkEditMac/Sources/Editor/Controllers/EditorViewController+Delegate.swift
+++ b/MarkEditMac/Sources/Editor/Controllers/EditorViewController+Delegate.swift
@@ -24,6 +24,13 @@ extension EditorViewController: WKUIDelegate {
       Grammarly.shared.startOAuth(bridge: bridge.grammarly)
     }
 
+    // Instead of creating a new WebView, opening the link using the system default behavior.
+    //
+    // It's a local file when it starts with baseURL, replace it with folder path.
+    if let url = URL(string: url.absoluteString.replacingOccurrences(of: EditorWebView.baseURL?.absoluteString ?? "", with: document?.baseURL?.absoluteString ?? "")) {
+      NSWorkspace.shared.openOrReveal(url: url)
+    }
+
     return nil
   }
 }


### PR DESCRIPTION
Turns out we still need this for links opened with `window.open`, such as Grammarly auth.