### PR TITLE
Lazily call -[AXBBundleManager loadAXBundles]

### DIFF
--- a/MarkEdit.xcodeproj/project.pbxproj
+++ b/MarkEdit.xcodeproj/project.pbxproj
@@ -77,6 +77,7 @@
 		87BEF30129A88F6800596E17 /* EditorCustomization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87BEF30029A88F6800596E17 /* EditorCustomization.swift */; };
 		87CC48FD29CC01E100BE1441 /* TextBundle in Frameworks */ = {isa = PBXBuildFile; productRef = 87CC48FC29CC01E100BE1441 /* TextBundle */; };
 		87D9322E2A925C6700B20D84 /* EditorReplaceTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87D9322D2A925C6700B20D84 /* EditorReplaceTextField.swift */; };
+		87DCB6202B284AAD00A3056F /* AppHacks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87DCB61F2B284AAD00A3056F /* AppHacks.swift */; };
 		87DE081B294DDA49004AD33A /* AppTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87DE081A294DDA49004AD33A /* AppTheme.swift */; };
 		87DE0825294DF340004AD33A /* EditorFindButtons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87DE0824294DF340004AD33A /* EditorFindButtons.swift */; };
 		87DE084B294E22C5004AD33A /* EditorViewController+TextFinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87DE084A294E22C5004AD33A /* EditorViewController+TextFinder.swift */; };
@@ -192,6 +193,7 @@
 		87BFF238298AAC75006C31E4 /* MarkEditTools */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = MarkEditTools; sourceTree = "<group>"; };
 		87C3CBFA29545944002A3436 /* MarkEditKit */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = MarkEditKit; sourceTree = "<group>"; };
 		87D9322D2A925C6700B20D84 /* EditorReplaceTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorReplaceTextField.swift; sourceTree = "<group>"; };
+		87DCB61F2B284AAD00A3056F /* AppHacks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppHacks.swift; sourceTree = "<group>"; };
 		87DE081A294DDA49004AD33A /* AppTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppTheme.swift; sourceTree = "<group>"; };
 		87DE0824294DF340004AD33A /* EditorFindButtons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorFindButtons.swift; sourceTree = "<group>"; };
 		87DE084A294E22C5004AD33A /* EditorViewController+TextFinder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EditorViewController+TextFinder.swift"; sourceTree = "<group>"; };
@@ -376,6 +378,7 @@
 			isa = PBXGroup;
 			children = (
 				871C99592973F1C2003FF3A7 /* Application */,
+				87DCB61F2B284AAD00A3056F /* AppHacks.swift */,
 				873D6401295FCC3E0095DEF7 /* AppResources.swift */,
 				87DE081A294DDA49004AD33A /* AppTheme.swift */,
 				87AAEE0129585ADC00C8E61C /* AppPreferences.swift */,
@@ -688,6 +691,7 @@
 				870F17662984D2C000003DA7 /* EditorViewController+LineEndings.swift in Sources */,
 				8790B6EC297036B2000DFC1A /* EditorWindow.swift in Sources */,
 				8765FD252AF28F1000C645A8 /* AppUpdater.swift in Sources */,
+				87DCB6202B284AAD00A3056F /* AppHacks.swift in Sources */,
 				874BE6F729BB57AC002F83BA /* IntentError.swift in Sources */,
 				87AA1224296560AE00BE4719 /* EditorViewController+HyperLink.swift in Sources */,
 				8725E0802977EEB3006A4961 /* EditorToolbarItems.swift in Sources */,

--- a/MarkEditKit/Sources/Extensions/NSObject+Extension.swift
+++ b/MarkEditKit/Sources/Extensions/NSObject+Extension.swift
@@ -6,6 +6,20 @@
 
 import Foundation
 
+public func safelyExchangeMethods(
+  type: AnyClass,
+  originalSelector: Selector,
+  originalMethod: IMP,
+  swizzledSelector: Selector,
+  swizzledMethod: IMP
+) {
+  if class_addMethod(type, originalSelector, method_getImplementation(swizzledMethod), method_getTypeEncoding(swizzledMethod)) {
+    class_replaceMethod(type, swizzledSelector, method_getImplementation(originalMethod), method_getTypeEncoding(originalMethod))
+  } else {
+    method_exchangeImplementations(originalMethod, swizzledMethod)
+  }
+}
+
 public extension NSObject {
   /// Exchange two class methods during runtime.
   static func exchangeClassMethods(originalSelector: Selector, swizzledSelector: Selector) {
@@ -49,10 +63,12 @@ private extension NSObject {
       return
     }
 
-    if class_addMethod(type, originalSelector, method_getImplementation(swizzledMethod), method_getTypeEncoding(swizzledMethod)) {
-      class_replaceMethod(type, swizzledSelector, method_getImplementation(originalMethod), method_getTypeEncoding(originalMethod))
-    } else {
-      method_exchangeImplementations(originalMethod, swizzledMethod)
-    }
+    safelyExchangeMethods(
+      type: type,
+      originalSelector: originalSelector,
+      originalMethod: originalMethod,
+      swizzledSelector: swizzledSelector,
+      swizzledMethod: swizzledMethod
+    )
   }
 }

--- a/MarkEditMac/Sources/Main/AppHacks.swift
+++ b/MarkEditMac/Sources/Main/AppHacks.swift
@@ -1,0 +1,68 @@
+//
+//  AppHacks.swift
+//  MarkEditMac
+//
+//  Created by cyan on 12/12/23.
+//
+
+import Foundation
+import MarkEditKit
+
+// [macOS 14] Performance regression, there's a good chance to hang at launch
+extension NSObject {
+  static var axbbmClass: AnyClass? {
+    // Joined as: /System/Library/PrivateFrameworks/AccessibilityBundles.framework
+    let path = [
+      "",
+      "System",
+      "Library",
+      "PrivateFrameworks",
+      "AccessibilityBundles.framework",
+    ].joined(separator: "/")
+
+    guard let bundle = Bundle(path: path), bundle.load() else {
+      Logger.assertFail("Failed to get the bundle")
+      return nil
+    }
+
+    return NSClassFromString("AXBBundleManager")
+  }
+
+  /**
+   Loading this bundle is extremely slow, move it to background thread with method swizzling.
+   */
+  static func swizzleAccessibilityBundles() {
+    guard #available(macOS 14.0, *) else {
+      return
+    }
+
+    guard let axbbmClass else {
+      return Logger.assertFail("Failed to get the class to swizzle")
+    }
+
+    let originalSelector = sel_getUid("loadAXBundles")
+    let swizzledSelector = #selector(swizzled_loadAXBundles)
+
+    guard let originalMethod = class_getInstanceMethod(axbbmClass, originalSelector), let swizzledMethod = class_getInstanceMethod(Self.self, swizzledSelector) else {
+      return Logger.assertFail("Failed to get the method to swizzle")
+    }
+
+    safelyExchangeMethods(
+      type: axbbmClass,
+      originalSelector: originalSelector,
+      originalMethod: originalMethod,
+      swizzledSelector: swizzledSelector,
+      swizzledMethod: swizzledMethod
+    )
+  }
+}
+
+// MARK: - Private
+
+private extension NSObject {
+  @objc func swizzled_loadAXBundles() {
+    DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + 1) {
+      self.swizzled_loadAXBundles()
+    }
+  }
+}

--- a/MarkEditMac/Sources/Main/Application/AppDelegate.swift
+++ b/MarkEditMac/Sources/Main/Application/AppDelegate.swift
@@ -50,6 +50,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     UserDefaults.overwriteTextCheckerOnce()
     EditorCustomization.createFiles()
 
+    NSObject.swizzleAccessibilityBundles()
     NSSpellChecker.swizzleInlineCompletionEnabledOnce
     NSSpellChecker.swizzleCorrectionIndicatorOnce
 

--- a/MarkEditMacTests/BundleTests.swift
+++ b/MarkEditMacTests/BundleTests.swift
@@ -5,6 +5,7 @@
 //  Created by cyan on 2/2/23.
 //
 
+@testable import MarkEdit
 import XCTest
 
 final class BundleTests: XCTestCase {

--- a/MarkEditMacTests/RuntimeTests.swift
+++ b/MarkEditMacTests/RuntimeTests.swift
@@ -5,6 +5,7 @@
 //  Created by cyan on 6/28/23.
 //
 
+@testable import MarkEdit
 import XCTest
 import WebKit
 import AppKitExtensions
@@ -79,6 +80,14 @@ final class RuntimeTests: XCTestCase {
     testExistenceOfClass(named: "NSToolbarFullScreenWindow")
     testExistenceOfClass(named: "NSTitlebarView")
     testExistenceOfClass(named: "NSToolbarButton")
+  }
+
+  func testPrivateAccessibilityBundles() {
+    let type: AnyClass? = NSObject.axbbmClass
+    XCTAssertNotNil(type, "Missing AXBBundleManager")
+
+    let object = type?.value(forKey: "defaultManager") as? AnyObject
+    XCTAssertEqual(object?.responds(to: sel_getUid("loadAXBundles")), true, "Missing loadAXBundles")
   }
 }
 


### PR DESCRIPTION
Reduces code launch time by 500ms on average, seems a very bad perf regression in Sonoma.