### PR TITLE
Revert IntentFile creation to use fileURL

### DIFF
--- a/MarkEditMac/Sources/Shortcuts/Intents/GetFileContentIntent.swift
+++ b/MarkEditMac/Sources/Shortcuts/Intents/GetFileContentIntent.swift
@@ -17,10 +17,6 @@ struct GetFileContentIntent: AppIntent {
       throw IntentError.missingDocument
     }
 
-    guard let fileData = try? Data(contentsOf: fileURL) else {
-      throw IntentError.missingDocument
-    }
-
-    return .result(value: IntentFile(data: fileData, filename: fileURL.lastPathComponent))
+    return .result(value: IntentFile(fileURL: fileURL))
   }
 }


### PR DESCRIPTION
It's not broken, it is just Shortcuts cannot handle the type as the final output. Related [#475 ](https://github.com/MarkEdit-app/MarkEdit/pull/469).