### PR TITLE
[macOS 15] Re-implement inline prediction acceptance

### DIFF
--- a/CoreEditor/src/bridge/native/completion.ts
+++ b/CoreEditor/src/bridge/native/completion.ts
@@ -14,5 +14,4 @@ export interface NativeModuleCompletion extends NativeModule {
   selectNext(): void;
   selectTop(): void;
   selectBottom(): void;
-  cancelInlinePrediction(): Promise<void>;
 }

--- a/CoreEditor/src/bridge/web/completion.ts
+++ b/CoreEditor/src/bridge/web/completion.ts
@@ -9,7 +9,7 @@ import { startCompletion, setPanelVisible, acceptInlinePrediction } from '../../
 export interface WebModuleCompletion extends WebModule {
   startCompletion({ afterDelay }: { afterDelay: number }): void;
   setState({ panelVisible }: { panelVisible: boolean }): void;
-  acceptInlinePrediction(): void;
+  acceptInlinePrediction({ prediction }: { prediction: string }): void;
 }
 
 export class WebModuleCompletionImpl implements WebModuleCompletion {
@@ -21,7 +21,7 @@ export class WebModuleCompletionImpl implements WebModuleCompletion {
     setPanelVisible(panelVisible);
   }
 
-  acceptInlinePrediction(): void {
-    acceptInlinePrediction();
+  acceptInlinePrediction({ prediction }: { prediction: string }): void {
+    acceptInlinePrediction(prediction);
   }
 }

--- a/MarkEditKit/Sources/Bridge/Native/Generated/NativeModuleCompletion.swift
+++ b/MarkEditKit/Sources/Bridge/Native/Generated/NativeModuleCompletion.swift
@@ -19,7 +19,6 @@ public protocol NativeModuleCompletion: NativeModule {
   func selectNext()
   func selectTop()
   func selectBottom()
-  func cancelInlinePrediction()
 }
 
 public extension NativeModuleCompletion {
@@ -50,9 +49,6 @@ final class NativeBridgeCompletion: NativeBridge {
     },
     "selectBottom": { [weak self] in
       self?.selectBottom(parameters: $0)
-    },
-    "cancelInlinePrediction": { [weak self] in
-      self?.cancelInlinePrediction(parameters: $0)
     },
   ]
 
@@ -108,11 +104,6 @@ final class NativeBridgeCompletion: NativeBridge {
 
   private func selectBottom(parameters: Data) -> Result<Any?, Error>? {
     module.selectBottom()
-    return .success(nil)
-  }
-
-  private func cancelInlinePrediction(parameters: Data) -> Result<Any?, Error>? {
-    module.cancelInlinePrediction()
     return .success(nil)
   }
 }

--- a/MarkEditKit/Sources/Bridge/Native/Modules/EditorModuleCompletion.swift
+++ b/MarkEditKit/Sources/Bridge/Native/Modules/EditorModuleCompletion.swift
@@ -25,7 +25,6 @@ public protocol EditorModuleCompletionDelegate: AnyObject {
   func editorCompletionDidSelectNext(_ sender: EditorModuleCompletion)
   func editorCompletionDidSelectTop(_ sender: EditorModuleCompletion)
   func editorCompletionDidSelectBottom(_ sender: EditorModuleCompletion)
-  func editorCompletionCancelInlinePrediction(_ sender: EditorModuleCompletion)
 }
 
 public final class EditorModuleCompletion: NativeModuleCompletion {
@@ -92,10 +91,6 @@ public final class EditorModuleCompletion: NativeModuleCompletion {
 
   public func selectBottom() {
     delegate?.editorCompletionDidSelectBottom(self)
-  }
-
-  public func cancelInlinePrediction() {
-    delegate?.editorCompletionCancelInlinePrediction(self)
   }
 }
 

--- a/MarkEditKit/Sources/Bridge/Web/Generated/WebBridgeCompletion.swift
+++ b/MarkEditKit/Sources/Bridge/Web/Generated/WebBridgeCompletion.swift
@@ -42,7 +42,15 @@ public final class WebBridgeCompletion {
     webView?.invoke(path: "webModules.completion.setState", message: message, completion: completion)
   }
 
-  public func acceptInlinePrediction(completion: ((Result<Void, WKWebView.InvokeError>) -> Void)? = nil) {
-    webView?.invoke(path: "webModules.completion.acceptInlinePrediction", completion: completion)
+  public func acceptInlinePrediction(prediction: String, completion: ((Result<Void, WKWebView.InvokeError>) -> Void)? = nil) {
+    struct Message: Encodable {
+      let prediction: String
+    }
+
+    let message = Message(
+      prediction: prediction
+    )
+
+    webView?.invoke(path: "webModules.completion.acceptInlinePrediction", message: message, completion: completion)
   }
 }

--- a/MarkEditMac/Sources/Editor/Controllers/EditorViewController+Delegate.swift
+++ b/MarkEditMac/Sources/Editor/Controllers/EditorViewController+Delegate.swift
@@ -222,10 +222,6 @@ extension EditorViewController: EditorModuleCompletionDelegate {
   func editorCompletionDidSelectBottom(_ sender: EditorModuleCompletion) {
     completionContext.selectBottom()
   }
-
-  func editorCompletionCancelInlinePrediction(_ sender: EditorModuleCompletion) {
-    NSSpellChecker.shared.declineCorrectionIndicator(for: webView)
-  }
 }
 
 // MARK: - EditorModulePreviewDelegate

--- a/MarkEditMac/Sources/Editor/Controllers/EditorViewController+Events.swift
+++ b/MarkEditMac/Sources/Editor/Controllers/EditorViewController+Events.swift
@@ -24,7 +24,10 @@ extension EditorViewController {
           NSSpellChecker.shared.dismissCorrectionIndicator(for: self.webView)
         } else {
           // Accept inline prediction without adding any punctuations
-          self.bridge.completion.acceptInlinePrediction()
+          NSSpellChecker.shared.acceptWebKitInlinePrediction(
+            view: self.webView,
+            bridge: self.bridge.completion
+          )
         }
       }
 

--- a/MarkEditMac/Sources/Main/Application/Application.swift
+++ b/MarkEditMac/Sources/Main/Application/Application.swift
@@ -12,6 +12,7 @@ final class Application: NSApplication {
   static func main() {
     NSObject.swizzleAccessibilityBundlesOnce
     NSSpellChecker.swizzleInlineCompletionEnabledOnce
+    NSSpellChecker.swizzleShowCompletionForCandidateOnce
     NSSpellChecker.swizzleCorrectionIndicatorOnce
 
     let app = Self.shared

--- a/MarkEditMacTests/RuntimeTests.swift
+++ b/MarkEditMacTests/RuntimeTests.swift
@@ -42,6 +42,24 @@ final class RuntimeTests: XCTestCase {
     testExistenceOfSelector(object: checker, selector: "isAutomaticInlineCompletionEnabled")
   }
 
+  func testExistenceOfAutomaticInlinePredictionBeingPresented() {
+    guard #available(macOS 14.0, *) else {
+      return
+    }
+
+    let checker = NSSpellChecker.self
+    testExistenceOfSelector(object: checker, selector: "isAutomaticInlinePredictionBeingPresented")
+  }
+
+  func testExistenceOfShowCompletionForCandidate() {
+    guard #available(macOS 14.0, *) else {
+      return
+    }
+
+    let checker = NSSpellChecker()
+    testExistenceOfSelector(object: checker, selector: "showCompletionForCandidate:selectedRange:offset:inString:rect:view:completionHandler:")
+  }
+
   func testExistenceOfCancelCorrection() {
     let checker = NSSpellChecker()
     testExistenceOfSelector(object: checker, selector: "cancelCorrectionIndicatorForView:")


### PR DESCRIPTION
In macOS Sequoia, the predictive text is no longer part of the DOM. This approach works better in Sonoma too, since it is not an async call.