### PR TITLE
Better preview button for math, table and mermaid

### DIFF
--- a/CoreEditor/index.ts
+++ b/CoreEditor/index.ts
@@ -43,7 +43,7 @@ const config = isReleaseMode ? window.config : {
   suggestWhileTyping: false,
   autoCharacterPairs: true,
   localizable: {
-    previewButtonTitle: 'preview',
+    previewButtonTitle: 'Preview',
     cmdClickToOpenLink: '⌘-click to open link',
   },
 } as Config;

--- a/CoreEditor/src/modules/preview/index.css
+++ b/CoreEditor/src/modules/preview/index.css
@@ -1,4 +1,14 @@
+.cm-md-previewWrapper {
+  margin: 0 2px;
+  padding: 0 4px;
+  border-radius: 4px;
+  transition: background 0.2s ease-in-out;
+}
+
 .cm-md-previewButton {
   cursor: pointer;
-  text-decoration: underline;
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: 18px;
+  padding-inline-end: 18px;
 }

--- a/CoreEditor/src/styling/builder.ts
+++ b/CoreEditor/src/styling/builder.ts
@@ -181,6 +181,13 @@ function buildTheme(colors: EditorColors, scheme?: ColorScheme) {
     '.cm-md-frontMatter *': {
       color: colors.comment,
     },
+    '.cm-md-previewButton': {
+      backgroundImage: (() => {
+        const strokeColor = `%23${colors.comment.substring(1)}`; // %23 -> #
+        const strokeWidth = '1.5';
+        return `url('data:image/svg+xml,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M2.42012 12.7132C2.28394 12.4975 2.21584 12.3897 2.17772 12.2234C2.14909 12.0985 2.14909 11.9015 2.17772 11.7766C2.21584 11.6103 2.28394 11.5025 2.42012 11.2868C3.54553 9.50484 6.8954 5 12.0004 5C17.1054 5 20.4553 9.50484 21.5807 11.2868C21.7169 11.5025 21.785 11.6103 21.8231 11.7766C21.8517 11.9015 21.8517 12.0985 21.8231 12.2234C21.785 12.3897 21.7169 12.4975 21.5807 12.7132C20.4553 14.4952 17.1054 19 12.0004 19C6.8954 19 3.54553 14.4952 2.42012 12.7132Z" stroke="${strokeColor}" stroke-width="${strokeWidth}"/><path d="M12.0004 15C13.6573 15 15.0004 13.6569 15.0004 12C15.0004 10.3431 13.6573 9 12.0004 9C10.3435 9 9.0004 10.3431 9.0004 12C9.0004 13.6569 10.3435 15 12.0004 15Z" stroke="${strokeColor}" stroke-width="${strokeWidth}"/></svg>')`;
+      })(),
+    },
     '.cm-md-diff-added': {
       backgroundColor: colors.diffAdded,
     },

--- a/CoreEditor/src/views/index.ts
+++ b/CoreEditor/src/views/index.ts
@@ -12,19 +12,18 @@ export class PreviewWidget extends WidgetView {
 
   toDOM() {
     const span = document.createElement('span');
-    span.style.paddingLeft = '4px';
+    span.className = 'cm-md-previewWrapper';
 
-    // Only include paddingRight for katext because it can be inline
-    if (this.type == PreviewType.katex) {
-      span.style.paddingRight = '4px';
-    }
+    const color = `${window.colors?.text ?? '#666666'}20`;
+    span.addEventListener('mouseenter', () => span.style.background = color);
+    span.addEventListener('mouseleave', () => span.style.background = '');
 
     const button = span.appendChild(document.createElement('span'));
     button.setAttribute('data-code', this.code);
     button.setAttribute('data-type', this.type);
     button.setAttribute('data-pos', `${this.pos}`);
 
-    button.innerText = `[${window.config.localizable?.previewButtonTitle}]`;
+    button.title = window.config.localizable?.previewButtonTitle ?? '';
     button.className = 'cm-md-previewButton';
 
     return span;

--- a/MarkEditMac/Resources/Localizable.xcstrings
+++ b/MarkEditMac/Resources/Localizable.xcstrings
@@ -1759,7 +1759,7 @@
         }
       }
     },
-    "preview" : {
+    "Preview" : {
       "comment" : "Button title for code preview",
       "localizations" : {
         "zh-Hans" : {

--- a/MarkEditMac/Sources/Main/AppResources.swift
+++ b/MarkEditMac/Sources/Main/AppResources.swift
@@ -36,7 +36,7 @@ enum Localized {
     static let foldLine = String(localized: "Fold Line", comment: "Phrase used in CodeMirror fold a line")
     static let unfoldLine = String(localized: "Unfold Line", comment: "Phrase used in CodeMirror to unfold a line")
     static let defaultLinkTitle = String(localized: "title", comment: "Default title used for link insertion")
-    static let previewButtonTitle = String(localized: "preview", comment: "Button title for code preview")
+    static let previewButtonTitle = String(localized: "Preview", comment: "Button title for code preview")
     static let cmdClickToOpenLink = String(localized: "⌘-click to open link", comment: "Tooltip for links")
     static let tableColumnName = String(localized: "Column", comment: "Column name for table creation")
     static let tableItemName = String(localized: "Item", comment: "Item name for table creation")


### PR DESCRIPTION
Much better now:

<img src="https://github.com/user-attachments/assets/34c1050a-9743-48e5-a000-d6c83e51bcde" width=305>