### PR TITLE
Add NSCloseAlwaysConfirmsChanges to runtime config

### DIFF
--- a/MarkEditKit/Sources/Extensions/UserDefaults+Extension.swift
+++ b/MarkEditKit/Sources/Extensions/UserDefaults+Extension.swift
@@ -6,6 +6,9 @@
 
 import Foundation
 
+public let NSCloseAlwaysConfirmsChanges = "NSCloseAlwaysConfirmsChanges"
+public let NSQuitAlwaysKeepsWindows = "NSQuitAlwaysKeepsWindows"
+
 public extension UserDefaults {
   static func overwriteTextCheckerOnce() {
     let enabledFlag = "editor.overwrite-text-checker"

--- a/MarkEditMac/Sources/Editor/Models/EditorDocument.swift
+++ b/MarkEditMac/Sources/Editor/Models/EditorDocument.swift
@@ -191,6 +191,14 @@ extension EditorDocument {
   }
 
   override func autosave(withImplicitCancellability implicitlyCancellable: Bool) async throws {
+    // When "Ask to keep changes when closing documents" is enabled,
+    // changes are asked to save explicitly.
+    //
+    // The value can from either system settings or app level overwritten.
+    guard !UserDefaults.standard.bool(forKey: NSCloseAlwaysConfirmsChanges) else {
+      return
+    }
+
     await saveAsynchronously(userInitiated: false) {
       // The default autosave doesn't work when the app is about to terminate,
       // it is because we have to do it in an asynchronous way.

--- a/MarkEditMac/Sources/Main/AppPreferences.swift
+++ b/MarkEditMac/Sources/Main/AppPreferences.swift
@@ -39,10 +39,10 @@ enum AppPreferences {
 
     static var quitAlwaysKeepsWindows: Bool {
       get {
-        UserDefaults.standard.bool(forKey: "NSQuitAlwaysKeepsWindows")
+        UserDefaults.standard.bool(forKey: NSQuitAlwaysKeepsWindows)
       }
       set {
-        UserDefaults.standard.set(newValue, forKey: "NSQuitAlwaysKeepsWindows")
+        UserDefaults.standard.set(newValue, forKey: NSQuitAlwaysKeepsWindows)
       }
     }
   }

--- a/MarkEditMac/Sources/Main/AppRuntimeConfig.swift
+++ b/MarkEditMac/Sources/Main/AppRuntimeConfig.swift
@@ -22,6 +22,7 @@ enum AppRuntimeConfig {
     // swiftlint:disable discouraged_optional_boolean
 
     let autoCharacterPairs: Bool?
+    let closeAlwaysConfirmsChanges: Bool?
     let indentBehavior: EditorIndentBehavior?
     let writingToolsBehavior: String?
     let headerFontSizeDiffs: [Double]?
@@ -31,6 +32,7 @@ enum AppRuntimeConfig {
 
     enum CodingKeys: String, CodingKey {
       case autoCharacterPairs = "editor.autoCharacterPairs"
+      case closeAlwaysConfirmsChanges = "editor.closeAlwaysConfirmsChanges"
       case indentBehavior = "editor.indentBehavior"
       case writingToolsBehavior = "editor.writingToolsBehavior"
       case headerFontSizeDiffs = "editor.headerFontSizeDiffs"
@@ -41,6 +43,12 @@ enum AppRuntimeConfig {
   static var autoCharacterPairs: Bool {
     // Enable it by default
     currentDefinition?.autoCharacterPairs ?? true
+  }
+
+  // swiftlint:disable:next discouraged_optional_boolean
+  static var closeAlwaysConfirmsChanges: Bool? {
+    // Disable it by default
+    currentDefinition?.closeAlwaysConfirmsChanges
   }
 
   static var indentBehavior: EditorIndentBehavior {
@@ -77,6 +85,7 @@ enum AppRuntimeConfig {
 private extension AppRuntimeConfig {
   static let defaultDefinition = Definition(
     autoCharacterPairs: true,
+    closeAlwaysConfirmsChanges: nil,
     indentBehavior: .never,
     writingToolsBehavior: nil, // [macOS 15] Complete mode still has lots of bugs
     headerFontSizeDiffs: nil,

--- a/MarkEditMac/Sources/Main/Application/AppDelegate.swift
+++ b/MarkEditMac/Sources/Main/Application/AppDelegate.swift
@@ -7,6 +7,7 @@
 import AppKit
 import AppKitExtensions
 import SettingsUI
+import MarkEditKit
 
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate {
@@ -64,6 +65,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
       name: NSWindow.didResignKeyNotification,
       object: nil
     )
+
+    // App level setting for "Ask to keep changes when closing documents"
+    if let closeAlwaysConfirmsChanges = AppRuntimeConfig.closeAlwaysConfirmsChanges {
+      UserDefaults.standard.set(closeAlwaysConfirmsChanges, forKey: NSCloseAlwaysConfirmsChanges)
+    } else {
+      UserDefaults.standard.removeObject(forKey: NSCloseAlwaysConfirmsChanges)
+    }
 
     // [macOS 15] Detect WritingTools visibility (fragile), with Xcode 16 we use KVO instead
     if #available(macOS 15.1, *), AppRuntimeConfig.writingToolsBehavior == 1 /* complete */ {


### PR DESCRIPTION
https://github.com/MarkEdit-app/MarkEdit/wiki/Customization#editorclosealwaysconfirmschanges