### PR TITLE
Be consistent with SF Mono and ui-monospace

### DIFF
--- a/CoreEditor/index.ts
+++ b/CoreEditor/index.ts
@@ -35,7 +35,7 @@ initMarkEditModules();
 const config = isReleaseMode ? window.config : {
   text: pseudoDocument,
   theme: 'github-light',
-  fontFace: { family: 'ui-monospace' },
+  fontFace: { family: 'SF Mono, ui-monospace' },
   fontSize: 17,
   showLineNumbers: true,
   showActiveLineIndicator: true,

--- a/CoreEditor/src/styling/builder.ts
+++ b/CoreEditor/src/styling/builder.ts
@@ -72,7 +72,7 @@ const sharedStyles: { [selector: string]: StyleSpec } = {
   },
   '.cm-gutters': {
     borderRight: 'none',
-    fontFamily: 'ui-monospace, monospace',
+    fontFamily: 'SF Mono, ui-monospace, monospace',
   },
   '.cm-activeLineGutter': {
     backgroundColor: 'inherit',
@@ -97,7 +97,7 @@ const sharedStyles: { [selector: string]: StyleSpec } = {
     pointerEvents: 'none',
   },
   '.cm-md-monospace, .cm-md-monospace *, .cm-md-codeBlock *, .cm-md-table *': {
-    fontFamily: 'ui-monospace, monospace',
+    fontFamily: 'SF Mono, ui-monospace, monospace',
   },
   '.cm-md-inlineCode': {
     borderRadius: '3px',
@@ -114,7 +114,7 @@ const sharedHighlights = [
   { tag: [tags.emphasis, tags.quote], fontStyle: 'italic' },
   { tag: tags.strikethrough, textDecoration: 'line-through' },
   { tag: tags.link, textDecoration: 'underline' },
-  { tag: tags.monospace, fontFamily: 'ui-monospace, monospace' },
+  { tag: tags.monospace, fontFamily: 'SF Mono, ui-monospace, monospace' },
 ];
 
 function buildTheme(colors: EditorColors, scheme?: ColorScheme) {


### PR DESCRIPTION
This fixes the issue where `|` sometimes look super thin.