### PR TITLE
Fix issues working with inline predictions

### DIFF
--- a/CoreEditor/src/modules/events/index.ts
+++ b/CoreEditor/src/modules/events/index.ts
@@ -23,6 +23,8 @@ export function startObserving() {
       link.startClickable();
       task.startClickable();
     }
+
+    storage.keyPressTime = Date.now();
   });
 
   document.addEventListener('keyup', event => {
@@ -99,6 +101,10 @@ export function isMetaKeyDown() {
   return storage.isMetaKeyDown;
 }
 
+export function hasRecentKeyPress() {
+  return Date.now() - storage.keyPressTime < 150;
+}
+
 export function resetKeyStates() {
   storage.isMouseDown = false;
   storage.isMetaKeyDown = false;
@@ -162,10 +168,12 @@ const storage: {
   scrollTimer: ReturnType<typeof setTimeout> | undefined;
   isMouseDown: boolean;
   isMetaKeyDown: boolean;
+  keyPressTime: number;
   selectedTextBeforeCompose: boolean;
 } = {
   scrollTimer: undefined,
   isMouseDown: false,
   isMetaKeyDown: false,
+  keyPressTime: 0,
   selectedTextBeforeCompose: false,
 };

--- a/CoreEditor/src/modules/lines/index.ts
+++ b/CoreEditor/src/modules/lines/index.ts
@@ -22,6 +22,37 @@ export function getVisibleLines() {
   return lines;
 }
 
+export function getLineElement(pos: number): HTMLElement | null {
+  let node: Node | null = window.editor.domAtPos(pos).node;
+  while (node && !(node instanceof HTMLElement && node.classList.contains('cm-line'))) {
+    node = node.parentNode;
+  }
+
+  return node;
+}
+
+export function adjustActiveLineGutter() {
+  if (!window.config.showLineNumbers) {
+    return;
+  }
+
+  const { selection, doc } = window.editor.state;
+  const { from: lineFrom, number: lineNumber } = doc.lineAt(selection.main.from);
+  const lineElement = getLineElement(lineFrom);
+  if (lineElement === null) {
+    return;
+  }
+
+  const gutterElement = [...document.querySelectorAll('.cm-lineNumbers .cm-gutterElement')].find((element: HTMLElement) => {
+    return parseInt(element.innerText) === lineNumber;
+  }) as HTMLElement | null;
+
+  if (gutterElement !== null) {
+    const height = lineElement.getBoundingClientRect().height;
+    gutterElement.style.height = `${height}px`;
+  }
+}
+
 export function adjustGutterPositions(className: 'lineNumbers' | 'gutterHover' = 'lineNumbers') {
   if (!window.config.showLineNumbers) {
     return;


### PR DESCRIPTION
This PR fixes two issues working with inline predictions:

- The line number gutter can have wrong height
- The caret can be misplaced while typing