### PR TITLE
Fix the issue where ".sb" backups are not removed

### DIFF
--- a/MarkEditMac/Sources/Editor/Controllers/EditorViewController+Delegate.swift
+++ b/MarkEditMac/Sources/Editor/Controllers/EditorViewController+Delegate.swift
@@ -102,7 +102,7 @@ extension EditorViewController: EditorModuleCoreDelegate {
       return
     }
 
-    document?.saveContent(userInitiated: false)
+    document?.saveContent()
   }
 
   func editorCoreBackgroundColorDidChange(_ sender: EditorModuleCore, color: UInt32) {

--- a/MarkEditMac/Sources/Extensions/NSDocumentController+Extension.swift
+++ b/MarkEditMac/Sources/Extensions/NSDocumentController+Extension.swift
@@ -13,7 +13,7 @@ extension NSDocumentController {
     !dirtyDocuments.isEmpty
   }
 
-  func saveDirtyDocuments(userInitiated: Bool = true) async {
+  func saveDirtyDocuments(userInitiated: Bool = false) async {
     await withTaskGroup(of: Void.self) { group in
       for document in dirtyDocuments {
         group.addTask {

--- a/MarkEditMac/Sources/Main/Application/AppDelegate.swift
+++ b/MarkEditMac/Sources/Main/Application/AppDelegate.swift
@@ -101,7 +101,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     if AppRuntimeConfig.autoSaveWhenIdle && NSDocumentController.shared.hasDirtyDocuments {
       // Terminate after all dirty documents are saved
       Task {
-        await NSDocumentController.shared.saveDirtyDocuments(userInitiated: false)
+        await NSDocumentController.shared.saveDirtyDocuments()
         application.terminate(nil)
       }
 


### PR DESCRIPTION
It looks like a macOS bug, when saving files, the system sometimes cannot remove the ".sb" backup files, it says no permisson.

This PR also reverted the default value of `userInitiated` since most cases are `false`.