### PR TITLE
Fix AppleScript 'save' Command

### DIFF
--- a/MarkEditMac/Resources/Localizable.xcstrings
+++ b/MarkEditMac/Resources/Localizable.xcstrings
@@ -273,13 +273,13 @@
         }
       }
     },
-    "Cannot export files with extension '%@'. Supported extensions: %@." : {
+    "Cannot export files with extension \"%@\". Supported extensions: %@." : {
       "comment" : "Script error when attempting to save files with an unsupported extension",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "Cannot export files with extension '%1$@'. Supported extensions: %2$@."
+            "value" : "Cannot export files with extension \"%1$@\". Supported extensions: %2$@."
           }
         }
       }
@@ -3343,6 +3343,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "寫作工具"
+          }
+        }
+      }
+    },
+    "Wrong file extension for type \"%@\". Use \".%@\" instead." : {
+      "comment" : "Script save error when the path extension does not match the output type",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Wrong file extension for type \"%1$@\". Use \".%2$@\" instead."
           }
         }
       }

--- a/MarkEditMac/Resources/Localizable.xcstrings
+++ b/MarkEditMac/Resources/Localizable.xcstrings
@@ -273,6 +273,17 @@
         }
       }
     },
+    "Cannot export files with extension '%@'. Supported extensions: %@." : {
+      "comment" : "Script error when attempting to save files with an unsupported extension",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Cannot export files with extension '%1$@'. Supported extensions: %2$@."
+          }
+        }
+      }
+    },
     "Case Sensitive" : {
       "comment" : "Toggle case sensitive search",
       "localizations" : {

--- a/MarkEditMac/Resources/MarkEdit.sdef
+++ b/MarkEditMac/Resources/MarkEdit.sdef
@@ -59,11 +59,12 @@
 
   <suite name="MarkEdit Suite" code="mked" description="MarkEdit specific classes.">
     <enumeration name="saveable file format" code="savf">
-      <enumerator name="Markdown" code="md  " description="Markdown format">
-        <cocoa string-value="net.daringfireball.markdown"/>
-      </enumerator>
-      <enumerator name="Text" code="txt " description="Plain text format">
+      <enumerator name="Plain Text" code="txt " description="Plain text format">
+        <synonym name="Markdown" code="md  "/>
         <cocoa string-value="public.text"/>
+      </enumerator>
+      <enumerator name="TextBundle" code="txtb" description="Text Bundle format">
+        <cocoa string-value="org.textbundle.package"/>
       </enumerator>
     </enumeration>
     

--- a/MarkEditMac/Resources/MarkEdit.sdef
+++ b/MarkEditMac/Resources/MarkEdit.sdef
@@ -58,12 +58,22 @@
   </suite>
 
   <suite name="MarkEdit Suite" code="mked" description="MarkEdit specific classes.">
-    <enumeration name="saveable file format" code="savf">
-      <enumerator name="Plain Text" code="txt " description="Plain text format">
-        <synonym name="Markdown" code="md  "/>
-        <cocoa string-value="public.text"/>
+    <enumeration name="saveable file format" code="savf" description="File formats for the save command.">
+      <documentation>
+        <html>
+          When using &lt;i&gt;save in &lt;b&gt;file&lt;/b&gt; as &lt;b&gt;type&lt;/b&gt;&lt;/i&gt;, the extension of &lt;b&gt;file&lt;/b&gt; must match the expected extension for &lt;b&gt;type&lt;/b&gt;. If &lt;b&gt;file&lt;/b&gt; has no extension, then the type is ignored.
+        </html>
+       </documentation>
+      <enumerator name="Plain Text" code="txt " description="Plain text format using the &quot;.txt&quot; extension.">
+        <cocoa string-value="app.markedit.txt"/>
       </enumerator>
-      <enumerator name="TextBundle" code="txtb" description="Text Bundle format">
+      <enumerator name="Markdown" code="md  " description="Markdown format using the &quot;.md&quot; extension.">
+        <cocoa string-value="app.markedit.md"/>
+      </enumerator>
+      <enumerator name="MarkdownFull" code="mkdn" description="Markdown format using the &quot;.markdown&quot; extension">
+        <cocoa string-value="app.markedit.markdown"/>
+      </enumerator>
+      <enumerator name="TextBundle" code="txtb" description="Text Bundle format using the &quot;.textbundle&quot; extension.">
         <cocoa string-value="org.textbundle.package"/>
       </enumerator>
     </enumeration>

--- a/MarkEditMac/Sources/Editor/Models/EditorDocument.swift
+++ b/MarkEditMac/Sources/Editor/Models/EditorDocument.swift
@@ -275,7 +275,7 @@ extension EditorDocument {
         return super.handleSave(command)
       } else {
         // Raise error because we cannot adjust the extension due to sandbox restrictions
-        let scriptError = ScriptingError.extensionMistach(fileURL, expectedExtension: desiredExtenion, outputType: desiredType)
+        let scriptError = ScriptingError.extensionMistach(expectedExtension: desiredExtenion, outputType: desiredType)
         scriptError.applyToCommand(command)
         return nil
       }
@@ -283,7 +283,7 @@ extension EditorDocument {
 
     let isValidExtension = NewFilenameExtension.allCases.contains {
       $0.rawValue == inputExtension
-    } || (textBundle != nil) && inputExtension == "textbundle"
+    } || (textBundle != nil && inputExtension == "textbundle")
 
     guard isValidExtension else {
       let scriptError = ScriptingError.invalidDestination(fileURL, document: self)

--- a/MarkEditMac/Sources/Editor/Models/EditorDocument.swift
+++ b/MarkEditMac/Sources/Editor/Models/EditorDocument.swift
@@ -260,7 +260,7 @@ extension EditorDocument {
     // Support extensionless paths by bypassing file type validation
     if inputExtension.isEmpty {
       Task {
-        try await save(to: fileURL.deletingPathExtension(), ofType: "", for: .saveToOperation)
+        try await save(to: fileURL.deletingPathExtension(), ofType: "", for: .saveOperation)
       }
       return nil
     }

--- a/MarkEditMac/Sources/Editor/Models/EditorDocument.swift
+++ b/MarkEditMac/Sources/Editor/Models/EditorDocument.swift
@@ -225,7 +225,7 @@ extension EditorDocument {
   }
 
   override func writableTypes(for saveOperation: NSDocument.SaveOperationType) -> [String] {
-    // Support all markdown and plaintext types, but prioritize the configured default
+    // Include all markdown and plaintext types, but prioritize the configured default
     var exportTypes = NewFilenameExtension.allCases
       .sorted { lhs, _ in
         lhs.rawValue == AppPreferences.General.newFilenameExtension.rawValue
@@ -252,7 +252,11 @@ extension EditorDocument {
     }
 
     let fileExtension = fileURL.pathExtension.lowercased()
-    guard NewFilenameExtension.allCases.contains(where: { $0.rawValue == fileExtension }) else {
+    let isValidExtension = NewFilenameExtension.allCases.contains {
+      $0.rawValue == fileExtension
+    } || ((textBundle != nil) && fileExtension == "textbundle")
+
+    guard isValidExtension else {
       let scriptError = ScriptingError.invalidDestination(fileURL, document: self)
       scriptError.applyToCommand(command)
       return nil

--- a/MarkEditMac/Sources/Main/AppResources.swift
+++ b/MarkEditMac/Sources/Main/AppResources.swift
@@ -223,7 +223,8 @@ enum Localized {
     static let editorNotFoundErrorMessage = String(localized: "No editor for document \"%@\" found.", comment: "Script error when MarkEdit cannot find the editor view to run document commands in")
     static let jsEvaluationErrorMessage = String(localized: "JavaScript evaluation failed at line %d, column %d: %@", comment: "Script error when JavaScript evaluation raises a detailed error")
     static let unknownJSErrorMessage = String(localized: "JavaScript evaluation failed for an unknown reason.", comment: "Script error when JavaScript evaluation raises an error with no details")
-    static let invalidDestinationErrorMessage = String(localized: "Cannot export files with extension '%@'. Supported extensions: %@.", comment: "Script error when attempting to save files with an unsupported extension")
+    static let invalidDestinationErrorMessage = String(localized: "Cannot export files with extension \"%@\". Supported extensions: %@.", comment: "Script error when attempting to save files with an unsupported extension")
+    static let extensionMismatchErrorMessage = String(localized: "Wrong file extension for type \"%@\". Use \".%@\" instead.", comment: "Script save error when the path extension does not match the output type")
   }
 
   enum Updater {

--- a/MarkEditMac/Sources/Main/AppResources.swift
+++ b/MarkEditMac/Sources/Main/AppResources.swift
@@ -223,6 +223,7 @@ enum Localized {
     static let editorNotFoundErrorMessage = String(localized: "No editor for document \"%@\" found.", comment: "Script error when MarkEdit cannot find the editor view to run document commands in")
     static let jsEvaluationErrorMessage = String(localized: "JavaScript evaluation failed at line %d, column %d: %@", comment: "Script error when JavaScript evaluation raises a detailed error")
     static let unknownJSErrorMessage = String(localized: "JavaScript evaluation failed for an unknown reason.", comment: "Script error when JavaScript evaluation raises an error with no details")
+    static let invalidDestinationErrorMessage = String(localized: "Cannot export files with extension '%@'. Supported extensions: %@.", comment: "Script error when attempting to save files with an unsupported extension")
   }
 
   enum Updater {

--- a/MarkEditMac/Sources/Scripting/Error+Scripting.swift
+++ b/MarkEditMac/Sources/Scripting/Error+Scripting.swift
@@ -51,14 +51,12 @@ enum ScriptingError: Error, LocalizedError {
         errorMessage
       )
     case let .invalidDestination(_: fileURL, document: document):
-      let fileExtension = fileURL.pathExtension
-
       let validTypes = document.writableTypes(for: .saveOperation)
       let validExtensions = validTypes.compactMap {
         document.fileNameExtension(forType: $0, saveOperation: .saveOperation)
       }
 
-      return String(format: Localized.Scripting.invalidDestinationErrorMessage, fileExtension, validExtensions.joined(separator: ", "))
+      return String(format: Localized.Scripting.invalidDestinationErrorMessage, fileURL.pathExtension, validExtensions.joined(separator: ", "))
     }
   }
 

--- a/MarkEditMac/Sources/Scripting/Error+Scripting.swift
+++ b/MarkEditMac/Sources/Scripting/Error+Scripting.swift
@@ -13,6 +13,7 @@ enum ScriptingError: Error, LocalizedError {
   case editorNotFound(_ documentName: String)
   case jsEvaluationError(_ error: NSError)
   case invalidDestination(_ fileURL: URL, document: EditorDocument)
+  case extensionMistach(_ fileURL: URL, expectedExtension: String, outputType: String)
 
   var code: Int {
     switch self {
@@ -25,6 +26,8 @@ enum ScriptingError: Error, LocalizedError {
     case .jsEvaluationError(_: let error):
       return error.code // WKError.javaScriptExceptionOccurred -- 4
     case .invalidDestination:
+      return NSArgumentsWrongScriptError
+    case .extensionMistach:
       return NSArgumentsWrongScriptError
     }
   }
@@ -55,8 +58,9 @@ enum ScriptingError: Error, LocalizedError {
       let validExtensions = validTypes.compactMap {
         document.fileNameExtension(forType: $0, saveOperation: .saveOperation)
       }
-
       return String(format: Localized.Scripting.invalidDestinationErrorMessage, fileURL.pathExtension, validExtensions.joined(separator: ", "))
+    case let .extensionMistach(_, expectedExtension: expectedExtension, outputType: outputType):
+      return String(format: Localized.Scripting.extensionMismatchErrorMessage, outputType, expectedExtension)
     }
   }
 

--- a/MarkEditMac/Sources/Scripting/Error+Scripting.swift
+++ b/MarkEditMac/Sources/Scripting/Error+Scripting.swift
@@ -12,6 +12,7 @@ enum ScriptingError: Error, LocalizedError {
   case missingArgument(_ name: String)
   case editorNotFound(_ documentName: String)
   case jsEvaluationError(_ error: NSError)
+  case invalidDestination(_ fileURL: URL, document: EditorDocument)
 
   var code: Int {
     switch self {
@@ -23,6 +24,8 @@ enum ScriptingError: Error, LocalizedError {
       return NSReceiverEvaluationScriptError
     case .jsEvaluationError(_: let error):
       return error.code // WKError.javaScriptExceptionOccurred -- 4
+    case .invalidDestination:
+      return NSArgumentsWrongScriptError
     }
   }
 
@@ -47,6 +50,15 @@ enum ScriptingError: Error, LocalizedError {
         columnNumber,
         errorMessage
       )
+    case let .invalidDestination(_: fileURL, document: document):
+      let fileExtension = fileURL.pathExtension
+
+      let validTypes = document.writableTypes(for: .saveOperation)
+      let validExtensions = validTypes.compactMap {
+        document.fileNameExtension(forType: $0, saveOperation: .saveOperation)
+      }
+
+      return String(format: Localized.Scripting.invalidDestinationErrorMessage, fileExtension, validExtensions.joined(separator: ", "))
     }
   }
 

--- a/MarkEditMac/Sources/Scripting/Error+Scripting.swift
+++ b/MarkEditMac/Sources/Scripting/Error+Scripting.swift
@@ -13,7 +13,7 @@ enum ScriptingError: Error, LocalizedError {
   case editorNotFound(_ documentName: String)
   case jsEvaluationError(_ error: NSError)
   case invalidDestination(_ fileURL: URL, document: EditorDocument)
-  case extensionMistach(_ fileURL: URL, expectedExtension: String, outputType: String)
+  case extensionMistach(expectedExtension: String, outputType: String)
 
   var code: Int {
     switch self {
@@ -59,7 +59,7 @@ enum ScriptingError: Error, LocalizedError {
         document.fileNameExtension(forType: $0, saveOperation: .saveOperation)
       }
       return String(format: Localized.Scripting.invalidDestinationErrorMessage, fileURL.pathExtension, validExtensions.joined(separator: ", "))
-    case let .extensionMistach(_, expectedExtension: expectedExtension, outputType: outputType):
+    case let .extensionMistach(expectedExtension: expectedExtension, outputType: outputType):
       return String(format: Localized.Scripting.extensionMismatchErrorMessage, outputType, expectedExtension)
     }
   }


### PR DESCRIPTION
I've adjusted a few functions in `EditorDocument` to fix problems with AppleScript's `save` command. Instead of requiring export paths to match the "New Filename Extension" setting, I've made it so that settings it prioritized but other extensions are still permitted.

Previously MarkEdit would throw an error if the 'New Filename Extension' setting was _'Markdown'_ and the the output path (in a script) was _'/Users/exampleUser/Downloads/test.md'_. The error would appear in MarkEdit itself, so scripts would get stuck until you manually dismissed the error within the app.

![errors](https://github.com/user-attachments/assets/9674668d-5e6d-4dc8-b1e0-cadd3b3ac8de)

Test script:

```applescript
tell application "MarkEdit"
	set myDownloads to POSIX path of (path to downloads folder)
	
	-- Assuming document 1 is a TextBundle, these all work as expected
	save document 1 in POSIX file (myDownloads & "example.md")
	save document 1 in POSIX file (myDownloads & "example.markdown")
	save document 1 in POSIX file (myDownloads & "example.txt")
	save document 1 in POSIX file (myDownloads & "example.textbundle")
	
	try
		save document 1 in POSIX file (myDownloads & "example.csv")
	on error err
		log err -- (*Cannot export files with extension 'csv'. Supported extensions: textbundle, markdown, md, txt.*)
	end try
end tell
```