### PR TITLE
Move asterisk and underscore back to marksToWrap

### DIFF
--- a/CoreEditor/src/modules/input/index.ts
+++ b/CoreEditor/src/modules/input/index.ts
@@ -61,7 +61,7 @@ export function wordTokenizer() {
  * @returns True to ignore the default behavior
  */
 export function interceptInputs() {
-  const marksToWrap = ['~', '$'];
+  const marksToWrap = ['*', '_', '~', '$'];
 
   return EditorView.inputHandler.of((editor, _from, _to, insert) => {
     // Enable auto character pairs only after composition ends,

--- a/CoreEditor/src/styling/markdown.ts
+++ b/CoreEditor/src/styling/markdown.ts
@@ -59,7 +59,7 @@ export const markdownExtendedData = {
       // Default
       '(', '[', '{', '\'', '"',
       // Custom
-      '`', '*', '_',
+      '`',
     ],
   },
 };


### PR DESCRIPTION
It doesn't make sense to have pairs inserted for them without text selection; they are widely used for many purposes.