### PR TITLE
Fix .cm-focused selector doesn't work properly

### DIFF
--- a/CoreEditor/index.css
+++ b/CoreEditor/index.css
@@ -34,6 +34,11 @@ html, body {
   pointer-events: none;
 }
 
+.cm-focused {
+  /* Disable the dashed border when the editor is focused */
+  outline: none !important;
+}
+
 /* Markdown */
 
 .cm-md-header {

--- a/CoreEditor/src/styling/builder.ts
+++ b/CoreEditor/src/styling/builder.ts
@@ -48,9 +48,6 @@ const sharedStyles: { [selector: string]: StyleSpec } = {
     // it can be an issue for whitespace rendering, especially for "selection" mode.
     whiteSpace: 'pre-wrap',
   },
-  '.cm-focused': {
-    outline: 'none',
-  },
   '.cm-foldGutter': {
     padding: '0 4px',
     opacity: '0',


### PR DESCRIPTION
It's unclear why using the built-in method doesn't work.