### PR TITLE
Allow opening all file types

### DIFF
--- a/MarkEditKit/Sources/Extensions/URL+Extension.swift
+++ b/MarkEditKit/Sources/Extensions/URL+Extension.swift
@@ -5,6 +5,7 @@
 //
 
 import Foundation
+import UniformTypeIdentifiers
 
 public extension URL {
   var localizedName: String {
@@ -24,6 +25,18 @@ public extension URL {
     }
   }
 
+  var isBinaryFile: Bool {
+    if textFileExtensions.contains(pathExtension.lowercased()) {
+      return false
+    }
+
+    if suggestedFileType?.conforms(to: .text) ?? true {
+      return false
+    }
+
+    return true
+  }
+
   func replacingPathExtension(_ pathExtension: String) -> URL {
     deletingPathExtension().appendingPathExtension(pathExtension)
   }
@@ -35,4 +48,28 @@ private extension URL {
   var isSymbolicLink: Bool {
     (try? resourceValues(forKeys: [.isSymbolicLinkKey]).isSymbolicLink) ?? false
   }
+
+  var suggestedFileType: UTType? {
+    if let associatedType = (try? resourceValues(forKeys: [.contentTypeKey]))?.contentType {
+      return associatedType
+    }
+
+    return UTType(filenameExtension: pathExtension)
+  }
 }
+
+private let textFileExtensions = Set(
+  [
+    "md",
+    "markdown",
+    "mdown",
+    "mdwn",
+    "mkdn",
+    "mkd",
+    "mdoc",
+    "mdtext",
+    "mdtxt",
+    "textbundle",
+    "txt",
+  ]
+)

--- a/MarkEditMac/Info.plist
+++ b/MarkEditMac/Info.plist
@@ -88,6 +88,22 @@
 			<key>NSDocumentClass</key>
 			<string>$(PRODUCT_MODULE_NAME).EditorDocument</string>
 		</dict>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>Binary File</string>
+			<key>LSTypeIsPackage</key>
+			<false/>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSHandlerRank</key>
+			<string>Alternate</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.data</string>
+			</array>
+			<key>NSDocumentClass</key>
+			<string>$(PRODUCT_MODULE_NAME).EditorDocument</string>
+		</dict>
 	</array>
 	<key>NSAppleScriptEnabled</key>
 	<true/>

--- a/MarkEditMac/Sources/Extensions/Bundle+Extension.swift
+++ b/MarkEditMac/Sources/Extensions/Bundle+Extension.swift
@@ -5,7 +5,7 @@
 //  Created by cyan on 6/11/25.
 //
 
-import Foundation
+import AppKit
 
 extension Bundle {
   static let swizzleInfoDictionaryOnce: () = {
@@ -24,5 +24,17 @@ extension Bundle {
     dict["UIDesignRequiresCompatibility"] = true
 
     return dict
+  }
+
+  func isDefaultApp(toOpen url: URL) -> Bool {
+    guard let defaultAppURL = NSWorkspace.shared.urlForApplication(toOpen: url) else {
+      return false
+    }
+
+    guard let defaultAppBundleID = Bundle(url: defaultAppURL)?.bundleIdentifier else {
+      return false
+    }
+
+    return defaultAppBundleID == bundleIdentifier
   }
 }

--- a/MarkEditMac/Sources/Main/AppDocumentController.swift
+++ b/MarkEditMac/Sources/Main/AppDocumentController.swift
@@ -39,6 +39,30 @@ final class AppDocumentController: NSDocumentController {
     return await super.beginOpenPanel(openPanel, forTypes: inTypes)
   }
 
+  override func openDocument(
+    withContentsOf url: URL,
+    display displayDocument: Bool,
+    completionHandler: @escaping (NSDocument?, Bool, (any Error)?) -> Void
+  ) {
+    if url.isBinaryFile {
+      // Dead loop prevention
+      if Bundle.main.isDefaultApp(toOpen: url) {
+        NSWorkspace.shared.activateFileViewerSelecting([url])
+      } else {
+        NSWorkspace.shared.open(url)
+      }
+
+      // Ignore the default opening logic
+      completionHandler(nil, false, nil)
+    } else {
+      super.openDocument(
+        withContentsOf: url,
+        display: displayDocument,
+        completionHandler: completionHandler
+      )
+    }
+  }
+
   override func saveAllDocuments(_ sender: Any?) {
     // The default implementation doesn't work
     documents.forEach { $0.save(sender) }


### PR DESCRIPTION
Make the file open panel available for all file types, only plain text files are handled by MarkEdit, others are either being opened by the associated default app or being revealed in Finder.

This makes the open panel more useful as we can delete or directly open files.