### PR TITLE
Silent @codemirror/lang-markdown warning

### DIFF
--- a/CoreEditor/package.json
+++ b/CoreEditor/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@codemirror/autocomplete": "^6.0.0",
     "@codemirror/commands": "^6.0.0",
+    "@codemirror/lang-markdown": "^6.0.0",
     "@codemirror/lang-yaml": "^6.0.0",
     "@codemirror/language": "^6.0.0",
     "@codemirror/language-data": "^6.0.0",

--- a/CoreEditor/yarn.lock
+++ b/CoreEditor/yarn.lock
@@ -5080,6 +5080,7 @@ __metadata:
   dependencies:
     "@codemirror/autocomplete": "npm:^6.0.0"
     "@codemirror/commands": "npm:^6.0.0"
+    "@codemirror/lang-markdown": "npm:^6.0.0"
     "@codemirror/lang-yaml": "npm:^6.0.0"
     "@codemirror/language": "npm:^6.0.0"
     "@codemirror/language-data": "npm:^6.0.0"


### PR DESCRIPTION
This is mainly to silent the yarn warning. We don't really use the official package, instead a local package is used.