### PR TITLE
More efficient controller warm-up

### DIFF
--- a/MarkEditMac/Sources/Editor/Models/EditorReusePool.swift
+++ b/MarkEditMac/Sources/Editor/Models/EditorReusePool.swift
@@ -16,47 +16,37 @@ final class EditorReusePool {
   static let shared = EditorReusePool()
 
   func warmUp() {
-    while controllerPool.count < Constants.numberOfWarmUp {
-      controllerPool.append(EditorViewController())
-    }
+    // Pre-load an instance so the first dequeue uses it,
+    // subsequent dequeues rotate the preloaded controller.
+    preloadedController = EditorViewController()
 
     // Try if warmup can fix the empty suggestion bug
     NSSpellChecker.shared.checkSpelling(of: "warmup", startingAt: 0)
   }
 
   func dequeueViewController() -> EditorViewController {
-    if let reusable = (controllerPool.first { $0.view.window == nil }) {
-      return reusable
-    }
-
-    let controller = EditorViewController()
-    if controllerPool.count < Constants.numberOfKeepAlive {
-      // The theory here is that loading resources from WKWebViews is expensive,
-      // we make a pool that always keeps a few instances in memory,
-      // if users open more editors than that, it's expected to be slower.
-      controllerPool.append(controller)
-    }
+    let controller = preloadedController ?? EditorViewController()
+    preloadedController = EditorViewController()
 
     return controller
   }
 
   /// All editors, whether with or without a visible window.
   func viewControllers() -> [EditorViewController] {
-    controllerPool + {
-      let windows = NSApplication.shared.windows.compactMap { $0 as? EditorWindow }
-      let controllers = windows.compactMap { $0.contentViewController as? EditorViewController }
-      return controllers.filter { !controllerPool.contains($0) }
-    }()
+    let windows = NSApp.windows.compactMap {
+      $0 as? EditorWindow
+    }
+
+    let controllers = windows.compactMap {
+      $0.contentViewController as? EditorViewController
+    }
+
+    return controllers.filter { $0 !== preloadedController } + [preloadedController].compactMap { $0 }
   }
 
   // MARK: - Private
 
-  private var controllerPool = [EditorViewController]()
+  private var preloadedController: EditorViewController?
 
   private init() {}
-
-  private enum Constants {
-    static let numberOfWarmUp: Int = 2
-    static let numberOfKeepAlive: Int = 3
-  }
 }


### PR DESCRIPTION
Instead of keeping a number of instances in memory, this approach now pre-load only one instance and always manipulate that one.

This works better in terms of both performance and memory usage.