### PR TITLE
Re-implement search field bezel

### DIFF
--- a/MarkEditMac/Modules/Sources/AppKitControls/LabeledSearchField.swift
+++ b/MarkEditMac/Modules/Sources/AppKitControls/LabeledSearchField.swift
@@ -11,6 +11,15 @@ public final class LabeledSearchField: NSSearchField {
   private let modernStyle: Bool
   private let bezelView = BezelView(cornerRadius: Constants.bezelCornerRadius)
 
+  // To render custom icons in modern style due to the unwanted bezel added by Apple
+  private lazy var searchIconView = CustomIconView()
+  private lazy var cancelIconView: CustomIconView = {
+    let view = CustomIconView()
+    view.isHidden = true
+
+    return view
+  }()
+
   private let labelView = {
     let label = LabelView(frame: .zero)
     label.font = .monospacedDigitSystemFont(ofSize: 12, weight: .regular)
@@ -55,7 +64,7 @@ public final class LabeledSearchField: NSSearchField {
       )
     }
 
-    // To completely clip the unnecessary capsule-style border
+    // To completely remove the unnecessary capsule-style border
     if modernStyle {
       #if DEBUG
         var hasAppKitSearchField = false
@@ -66,7 +75,7 @@ public final class LabeledSearchField: NSSearchField {
           #if DEBUG
             hasAppKitSearchField = true
           #endif
-          view.layer?.cornerRadius = view.frame.height * 0.5
+          renderCustomIcons(modernBezel: view)
         }
       }
 
@@ -90,10 +99,42 @@ public final class LabeledSearchField: NSSearchField {
     ).fill()
   }
 
+  override public var stringValue: String {
+    get {
+      super.stringValue
+    }
+    set {
+      super.stringValue = newValue
+      updateCustomCancelIcon()
+    }
+  }
+
+  override public func textDidChange(_ notification: Notification) {
+    super.textDidChange(notification)
+    updateCustomCancelIcon()
+  }
+
   public func updateLabel(text: String) {
     labelView.stringValue = text
     labelView.isHidden = text.isEmpty
     needsLayout = true
+  }
+
+  public func setSearchIconColor(_ tintColor: NSColor?) {
+    let buttonCell = searchButtonCell
+    let iconImage = buttonCell?.image?.copy() as? NSImage
+    iconImage?.setTintColor(tintColor)
+
+    // Must clear first
+    buttonCell?.image = nil
+    buttonCell?.image = iconImage
+
+    if modernStyle {
+      searchIconView.image = nil
+      searchIconView.image = iconImage
+    }
+
+    needsDisplay = true
   }
 }
 
@@ -102,5 +143,52 @@ public final class LabeledSearchField: NSSearchField {
 private extension LabeledSearchField {
   enum Constants {
     static let bezelCornerRadius: Double = 6.0
+  }
+
+  func renderCustomIcons(modernBezel: NSView) {
+    // This is used for styling only, user interactions are not handled here
+    modernBezel.isHidden = true
+
+    searchIconView.image = searchButtonCell?.image
+    searchIconView.frame = customIconBounds(for: searchButtonBounds)
+
+    cancelIconView.image = cancelButtonCell?.image
+    cancelIconView.frame = customIconBounds(for: cancelButtonBounds)
+
+    if searchIconView.superview == nil {
+      addSubview(searchIconView)
+    }
+
+    if cancelIconView.superview == nil {
+      addSubview(cancelIconView)
+    }
+
+    updateCustomCancelIcon()
+  }
+
+  func updateCustomCancelIcon() {
+    guard modernStyle else {
+      return
+    }
+
+    cancelIconView.isHidden = stringValue.isEmpty
+  }
+
+  func customIconBounds(for cellRect: CGRect) -> CGRect {
+    CGRect(x: cellRect.minX, y: 0, width: cellRect.width, height: frame.height)
+  }
+}
+
+private class CustomIconView: NSImageView {
+  override func hitTest(_ point: NSPoint) -> NSView? {
+    nil
+  }
+
+  override func isAccessibilityElement() -> Bool {
+    false
+  }
+
+  override func accessibilityRole() -> NSAccessibility.Role? {
+    .none
   }
 }

--- a/MarkEditMac/Modules/Sources/AppKitExtensions/UI/NSImage+Extension.swift
+++ b/MarkEditMac/Modules/Sources/AppKitExtensions/UI/NSImage+Extension.swift
@@ -36,4 +36,12 @@ public extension NSImage {
 
     return image
   }
+
+  func setTintColor(_ tintColor: NSColor?) {
+    guard responds(to: sel_getUid("_setTintColor:")) else {
+      return assertionFailure("Missing _setTintColor(_:) to change the tint color")
+    }
+
+    perform(sel_getUid("_setTintColor:"), with: tintColor)
+  }
 }

--- a/MarkEditMac/Modules/Sources/AppKitExtensions/UI/NSSearchField+Extension.swift
+++ b/MarkEditMac/Modules/Sources/AppKitExtensions/UI/NSSearchField+Extension.swift
@@ -12,6 +12,14 @@ public extension NSSearchField {
     subviews.first { $0.className.hasSuffix("FocusClipView") }
   }
 
+  var searchButtonCell: NSButtonCell? {
+    (cell as? NSSearchFieldCell)?.searchButtonCell
+  }
+
+  var cancelButtonCell: NSButtonCell? {
+    (cell as? NSSearchFieldCell)?.cancelButtonCell
+  }
+
   func addToRecents(searchTerm: String) {
     guard !searchTerm.isEmpty else {
       return
@@ -19,23 +27,5 @@ public extension NSSearchField {
 
     let recents = recentSearches.filter { $0 != searchTerm }
     recentSearches = [searchTerm] + recents
-  }
-
-  func setIconTintColor(_ tintColor: NSColor?) {
-    guard let buttonCell = (cell as? NSSearchFieldCell)?.searchButtonCell else {
-      return
-    }
-
-    guard let iconImage = buttonCell.image else {
-      return
-    }
-
-    guard iconImage.responds(to: sel_getUid("_setTintColor:")) else {
-      return
-    }
-
-    iconImage.perform(sel_getUid("_setTintColor:"), with: tintColor)
-    buttonCell.image = iconImage
-    needsDisplay = true
   }
 }

--- a/MarkEditMac/Sources/Panels/Find/EditorFindPanel+Menu.swift
+++ b/MarkEditMac/Sources/Panels/Find/EditorFindPanel+Menu.swift
@@ -116,6 +116,6 @@ private extension EditorFindPanel {
     })?.contains { $0.state == .on } ?? false
 
     let tintColor: NSColor? = shouldTint ? .controlAccentColor : nil
-    searchField.setIconTintColor(tintColor)
+    searchField.setSearchIconColor(tintColor)
   }
 }


### PR DESCRIPTION
We really don't have better choice.

In macOS Tahoe with Liquid Glass aesthetic, a private class `AppKitSearchField` is used to barely add background color, corner radius, shadows... private drawing makes impossible to customize it, as a developer.

To make it looks better fit our design, we had to hide it entirely.

Interestingly, search button and cancel button in this layer are "fake", they only shows the icons. This gives us a chance to draw our own icons. Mouse clicks and VoiceOver are not affected at all.