### PR TITLE
Fix transparency for legacy titlebar

### DIFF
--- a/MarkEditMac/Base.lproj/Main.storyboard
+++ b/MarkEditMac/Base.lproj/Main.storyboard
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="24506" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="24765" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="24506"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="24765"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -1085,7 +1085,7 @@ Gw
         <scene sceneID="R2V-B0-nI4">
             <objects>
                 <windowController storyboardIdentifier="EditorWindowController" id="jGA-0Y-lOj" userLabel="Editor Window Controller" customClass="EditorWindowController" customModule="MarkEdit" customModuleProvider="target" sceneMemberID="viewController">
-                    <window key="window" title="Window" separatorStyle="line" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" visibleAtLaunch="NO" frameAutosaveName="" animationBehavior="default" titlebarAppearsTransparent="YES" toolbarStyle="unified" id="Ckk-yw-fiv" customClass="EditorWindow" customModule="MarkEdit" customModuleProvider="target">
+                    <window key="window" title="Window" separatorStyle="line" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" visibleAtLaunch="NO" frameAutosaveName="" animationBehavior="default" toolbarStyle="unified" id="Ckk-yw-fiv" customClass="EditorWindow" customModule="MarkEdit" customModuleProvider="target">
                         <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES" fullSizeContentView="YES"/>
                         <rect key="contentRect" x="89" y="664" width="720" height="480"/>
                         <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1027"/>

--- a/MarkEditMac/Sources/Editor/Controllers/EditorViewController+TextFinder.swift
+++ b/MarkEditMac/Sources/Editor/Controllers/EditorViewController+TextFinder.swift
@@ -70,10 +70,6 @@ extension EditorViewController {
     findPanel.mode = mode
     findPanel.resetMenu()
 
-    // Titlebar divider isn't reliably shown in modern style, we use a custom view instead
-    let hideTitlebarDivider = mode == .hidden || AppDesign.modernStyle
-    view.window?.titlebarAppearsTransparent = hideTitlebarDivider
-
     // Move the focus back to editor
     if mode == .hidden {
       startTextEditing()

--- a/MarkEditMac/Sources/Editor/Controllers/EditorViewController+UI.swift
+++ b/MarkEditMac/Sources/Editor/Controllers/EditorViewController+UI.swift
@@ -226,6 +226,9 @@ extension EditorViewController {
     if AppDesign.modernTitleBar {
       modernEffectHeight.constant = view.safeAreaInsets.top + panelDivider.frame.height
       modernDividerView.update(animated).alphaValue = findPanel.mode == .hidden ? 0 : 1
+    } else {
+      // To avoid duplicate dividers on legacy titlebar
+      panelDivider.isHidden = findPanel.mode == .hidden
     }
 
     // The position of this divider should be fixed

--- a/MarkEditMac/Sources/Editor/EditorWindow.swift
+++ b/MarkEditMac/Sources/Editor/EditorWindow.swift
@@ -44,6 +44,7 @@ final class EditorWindow: NSWindow {
     toolbar = NSToolbar() // Required for multi-tab layout
     toolbarMode = AppPreferences.Window.toolbarMode
     tabbingMode = AppPreferences.Window.tabbingMode
+    titlebarAppearsTransparent = AppDesign.modernTitleBar
     reduceTransparency = AppDesign.reduceTransparency
   }
 


### PR DESCRIPTION
It should respect AppDesign.modernTitleBar. Closes #1351.