### PR TITLE
Change "Search Operations" to "Search Actions"

### DIFF
--- a/MarkEditMac/Resources/Localizable.xcstrings
+++ b/MarkEditMac/Resources/Localizable.xcstrings
@@ -2451,8 +2451,8 @@
         }
       }
     },
-    "Search Operations" : {
-      "comment" : "Search operations",
+    "Search Actions" : {
+      "comment" : "Search actions, like select all, select all in selection",
       "localizations" : {
         "zh-Hans" : {
           "stringUnit" : {

--- a/MarkEditMac/Sources/Editor/Controllers/EditorViewController+Delegate.swift
+++ b/MarkEditMac/Sources/Editor/Controllers/EditorViewController+Delegate.swift
@@ -49,8 +49,8 @@ extension EditorViewController: EditorWebViewActionDelegate {
     isReadOnlyMode
   }
 
-  func editorWebViewSearchOperationsMenuItem(_ webView: EditorWebView) -> NSMenuItem? {
-    searchOperationsMenuItem
+  func editorWebViewSearchActionsMenuItem(_ webView: EditorWebView) -> NSMenuItem? {
+    searchActionsMenuItem
   }
 
   func editorWebViewResignFirstResponder(_ webView: EditorWebView) {
@@ -377,8 +377,8 @@ extension EditorViewController: EditorFindPanelDelegate {
     updateTextFinderQuery()
   }
 
-  func editorFindPanelOperationsMenuItem(_ sender: EditorFindPanel) -> NSMenuItem? {
-    searchOperationsMenuItem
+  func editorFindPanelActionsMenuItem(_ sender: EditorFindPanel) -> NSMenuItem? {
+    searchActionsMenuItem
   }
 
   func editorFindPanelDidChangeOptions(_ sender: EditorFindPanel) {

--- a/MarkEditMac/Sources/Editor/Controllers/EditorViewController+Menu.swift
+++ b/MarkEditMac/Sources/Editor/Controllers/EditorViewController+Menu.swift
@@ -12,7 +12,7 @@ import FontPicker
 // MARK: - NSMenu Creation
 
 extension EditorViewController {
-  var searchOperationsMenuItem: NSMenuItem? {
+  var searchActionsMenuItem: NSMenuItem? {
     guard findPanel.mode != .hidden else {
       return nil
     }
@@ -39,7 +39,7 @@ extension EditorViewController {
       self?.performSearchOperation(.replaceAllInSelection)
     }.isEnabled = canReplace
 
-    let item = NSMenuItem(title: Localized.Search.searchOperations)
+    let item = NSMenuItem(title: Localized.Search.searchActions)
     item.tag = WKContextMenuItemTag.searchMenu.rawValue
     item.submenu = menu
     return item

--- a/MarkEditMac/Sources/Editor/Views/EditorWebView.swift
+++ b/MarkEditMac/Sources/Editor/Views/EditorWebView.swift
@@ -23,7 +23,7 @@ enum WKContextMenuItemTag: Int {
   case copyLinkWithHighlight = 102
 
   /**
-   Customized item that shows the search operations.
+   Customized item that shows the search actions.
    */
   case searchMenu = 0xbadbabe
 }
@@ -36,7 +36,7 @@ enum EditorWebViewMenuAction {
 @MainActor
 protocol EditorWebViewActionDelegate: AnyObject {
   func editorWebViewIsReadOnlyMode(_ webView: EditorWebView) -> Bool
-  func editorWebViewSearchOperationsMenuItem(_ webView: EditorWebView) -> NSMenuItem?
+  func editorWebViewSearchActionsMenuItem(_ webView: EditorWebView) -> NSMenuItem?
   func editorWebViewResignFirstResponder(_ webView: EditorWebView)
   func editorWebView(_ webView: EditorWebView, mouseDownWith event: NSEvent)
   func editorWebView(_ webView: EditorWebView, didSelect menuAction: EditorWebViewMenuAction)
@@ -106,8 +106,8 @@ final class EditorWebView: WKWebView {
       return true
     }
 
-    // Operations like select all in selection, replace all in selection, etc
-    if let searchMenuItem = actionDelegate?.editorWebViewSearchOperationsMenuItem(self) {
+    // Actions like select all in selection, replace all in selection, etc
+    if let searchMenuItem = actionDelegate?.editorWebViewSearchActionsMenuItem(self) {
       menu.insertItem(searchMenuItem, at: 0)
       menu.insertItem(.separator(), at: 1)
     }

--- a/MarkEditMac/Sources/Main/AppResources.swift
+++ b/MarkEditMac/Sources/Main/AppResources.swift
@@ -74,7 +74,7 @@ enum Localized {
     static let wholeWord = String(localized: "Whole Word", comment: "Toggle whole word search")
     static let literalSearch = String(localized: "Literal Search", comment: "Toggle literal search")
     static let regularExpression = String(localized: "Regular Expression", comment: "Toggle regular expression for search")
-    static let searchOperations = String(localized: "Search Operations", comment: "Search operations")
+    static let searchActions = String(localized: "Search Actions", comment: "Search actions, like select all, select all in selection")
     static let selectAll = String(localized: "Select All", comment: "Select all occurrences")
     static let selectAllInSelection = String(localized: "Select All in Selection", comment: "Select all occurrences in selection")
     static let replaceAll = String(localized: "Replace All", comment: "Replace all occurrences")

--- a/MarkEditMac/Sources/Panels/Find/EditorFindPanel+Menu.swift
+++ b/MarkEditMac/Sources/Panels/Find/EditorFindPanel+Menu.swift
@@ -37,8 +37,8 @@ extension EditorFindPanel {
     regexItem.setOn(AppPreferences.Search.regularExpression)
     menu.addItem(.separator())
 
-    if let operationsItem = delegate?.editorFindPanelOperationsMenuItem(self) {
-      menu.addItem(operationsItem)
+    if let actionsItem = delegate?.editorFindPanelActionsMenuItem(self) {
+      menu.addItem(actionsItem)
       menu.addItem(.separator())
     }
 

--- a/MarkEditMac/Sources/Panels/Find/EditorFindPanel.swift
+++ b/MarkEditMac/Sources/Panels/Find/EditorFindPanel.swift
@@ -22,7 +22,7 @@ enum EditorFindMode {
 protocol EditorFindPanelDelegate: AnyObject {
   func editorFindPanel(_ sender: EditorFindPanel, modeDidChange mode: EditorFindMode)
   func editorFindPanel(_ sender: EditorFindPanel, searchTermDidChange searchTerm: String)
-  func editorFindPanelOperationsMenuItem(_ sender: EditorFindPanel) -> NSMenuItem?
+  func editorFindPanelActionsMenuItem(_ sender: EditorFindPanel) -> NSMenuItem?
   func editorFindPanelDidChangeOptions(_ sender: EditorFindPanel)
   func editorFindPanelDidPressTabKey(_ sender: EditorFindPanel, isBacktab: Bool)
   func editorFindPanelDidClickNext(_ sender: EditorFindPanel)


### PR DESCRIPTION
The ts type `SearchOperation` is intentionally kept because it's the api (not user-facing).