### PR TITLE
Add quick tab switcher (Cmd+Shift+E) and always-show-tab-bar preference

### DIFF
--- a/MarkEdit.xcodeproj/project.pbxproj
+++ b/MarkEdit.xcodeproj/project.pbxproj
@@ -96,6 +96,7 @@
 		87BB5A2C2E929BAA00A17C14 /* AppExceptionCatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87BB5A292E929BA700A17C14 /* AppExceptionCatcher.swift */; };
 		87BD071229699A290053EF5F /* EditorViewController+Preview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87BD071129699A290053EF5F /* EditorViewController+Preview.swift */; };
 		87BDF6E42976C97100548079 /* EditorViewController+GotoLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87BDF6E32976C97100548079 /* EditorViewController+GotoLine.swift */; };
+		CC000002300000000000001A /* EditorViewController+TabSwitcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC000002300000000000001B /* EditorViewController+TabSwitcher.swift */; };
 		87BE2E342DF9B5C000A51CF4 /* Bundle+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87BE2E332DF9B5BB00A51CF4 /* Bundle+Extension.swift */; };
 		87BEF30129A88F6800596E17 /* AppCustomization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87BEF30029A88F6800596E17 /* AppCustomization.swift */; };
 		87CC48FD29CC01E100BE1441 /* TextBundle in Frameworks */ = {isa = PBXBuildFile; productRef = 87CC48FC29CC01E100BE1441 /* TextBundle */; };
@@ -236,6 +237,7 @@
 		87BB5A292E929BA700A17C14 /* AppExceptionCatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppExceptionCatcher.swift; sourceTree = "<group>"; };
 		87BD071129699A290053EF5F /* EditorViewController+Preview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EditorViewController+Preview.swift"; sourceTree = "<group>"; };
 		87BDF6E32976C97100548079 /* EditorViewController+GotoLine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EditorViewController+GotoLine.swift"; sourceTree = "<group>"; };
+		CC000002300000000000001B /* EditorViewController+TabSwitcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EditorViewController+TabSwitcher.swift"; sourceTree = "<group>"; };
 		87BE2E332DF9B5BB00A51CF4 /* Bundle+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+Extension.swift"; sourceTree = "<group>"; };
 		87BEF30029A88F6800596E17 /* AppCustomization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCustomization.swift; sourceTree = "<group>"; };
 		87BFF238298AAC75006C31E4 /* MarkEditTools */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = MarkEditTools; sourceTree = "<group>"; };
@@ -535,6 +537,7 @@
 				87AA1223296560AE00BE4719 /* EditorViewController+HyperLink.swift */,
 				87BD071129699A290053EF5F /* EditorViewController+Preview.swift */,
 				87BDF6E32976C97100548079 /* EditorViewController+GotoLine.swift */,
+				CC000002300000000000001B /* EditorViewController+TabSwitcher.swift */,
 				8790ABD32A98F5F40083825C /* EditorViewController+Statistics.swift */,
 				873126E3297BAC9C001521A0 /* EditorViewController+Pandoc.swift */,
 			);
@@ -783,6 +786,7 @@
 				8780AC1E2982A2C900065EF4 /* EditorSettingsView.swift in Sources */,
 				8767BBB5295AD62700BFACAE /* EditorReplaceButtons.swift in Sources */,
 				87BDF6E42976C97100548079 /* EditorViewController+GotoLine.swift in Sources */,
+				CC000002300000000000001A /* EditorViewController+TabSwitcher.swift in Sources */,
 				874BE6FB29BB5804002F83BA /* AppIntent+Extension.swift in Sources */,
 				87F2B5F429ACF56E0027103E /* EditorViewController+Completion.swift in Sources */,
 				8772E385294AC60D00111E83 /* EditorReusePool.swift in Sources */,

--- a/MarkEditMac/Base.lproj/Main.storyboard
+++ b/MarkEditMac/Base.lproj/Main.storyboard
@@ -422,6 +422,12 @@ Gw
                                                 <action selector="gotoLine:" target="Ady-hI-5gd" id="puP-5D-Fgc"/>
                                             </connections>
                                         </menuItem>
+                                        <menuItem title="Switch Document…" keyEquivalent="E" id="tsw-Tb-SwT">
+                                            <modifierMask key="keyEquivalentModifierMask" shift="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="showTabSwitcher:" target="Ady-hI-5gd" id="tsw-Ac-001"/>
+                                            </connections>
+                                        </menuItem>
                                         <menuItem title="Table of Contents" id="REb-f5-kpc">
                                             <modifierMask key="keyEquivalentModifierMask"/>
                                             <menu key="submenu" title="Table of Contents" id="BxI-nv-Xa5">

--- a/MarkEditMac/Modules/Sources/AppKitControls/TabSwitcher/TabSwitcherView.swift
+++ b/MarkEditMac/Modules/Sources/AppKitControls/TabSwitcher/TabSwitcherView.swift
@@ -1,0 +1,329 @@
+//
+//  TabSwitcherView.swift
+//
+//  Created by lamchau on 4/16/26.
+//
+
+import AppKit
+
+final class TabSwitcherView: NSView {
+  private enum Constants {
+    static let cornerRadius: Double = 12
+    static let padding: Double = 8
+    static let iconInset: Double = 4
+    static let dividerSpacing: Double = 4
+    static let searchHeight: Double = 36
+    static let rowHeight: Double = 32
+    static let iconWidth: Double = 20
+  }
+
+  private lazy var effectView: NSView = {
+    let view = effectViewType.init()
+    (view as? NSVisualEffectView)?.material = .popover
+
+    return view
+  }()
+
+  private let textField: NSTextField = {
+    let textField = NSTextField()
+    textField.font = .systemFont(ofSize: 16, weight: .light)
+    textField.focusRingType = .none
+    textField.drawsBackground = false
+    textField.isBezeled = false
+
+    return textField
+  }()
+
+  private let scrollView: NSScrollView = {
+    let scrollView = NSScrollView()
+    scrollView.hasVerticalScroller = true
+    scrollView.autohidesScrollers = true
+    scrollView.borderType = .noBorder
+    scrollView.drawsBackground = false
+
+    return scrollView
+  }()
+
+  private let tableView: NSTableView = {
+    let tableView = NSTableView()
+    tableView.headerView = nil
+    tableView.backgroundColor = .clear
+    tableView.rowHeight = Constants.rowHeight
+    tableView.selectionHighlightStyle = .regular
+    tableView.intercellSpacing = NSSize(width: 0, height: 2)
+
+    let column = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("tab"))
+    column.isEditable = false
+    tableView.addTableColumn(column)
+
+    return tableView
+  }()
+
+  private let effectViewType: NSView.Type
+  private var allItems: [TabSwitcherItem] = []
+  private var filteredItems: [TabSwitcherItem] = []
+
+  private lazy var emptyLabel: NSTextField = {
+    let label = NSTextField(labelWithString: "")
+    label.font = .systemFont(ofSize: 13, weight: .regular)
+    label.textColor = .secondaryLabelColor
+    label.alignment = .center
+    label.isHidden = true
+    label.translatesAutoresizingMaskIntoConstraints = false
+
+    return label
+  }()
+
+  init(
+    effectViewType: NSView.Type,
+    frame: CGRect,
+    placeholder: String,
+    accessibilityHelp: String,
+    emptyMessage: String,
+    items: [TabSwitcherItem],
+    initialSelection: Int = 0
+  ) {
+    self.effectViewType = effectViewType
+    self.allItems = items
+    self.filteredItems = items
+    super.init(frame: frame)
+
+    emptyLabel.stringValue = emptyMessage
+
+    wantsLayer = true
+    layer?.cornerCurve = .continuous
+    layer?.cornerRadius = Constants.cornerRadius
+    layer?.masksToBounds = true
+
+    setupSubviews(placeholder: placeholder, accessibilityHelp: accessibilityHelp)
+    selectRow(initialSelection)
+  }
+
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+}
+
+// MARK: - NSTextFieldDelegate
+
+extension TabSwitcherView: NSTextFieldDelegate {
+  func controlTextDidChange(_ obj: Notification) {
+    filterItems()
+  }
+
+  func control(_ control: NSControl, textView: NSTextView, doCommandBy selector: Selector) -> Bool {
+    switch selector {
+    case #selector(insertNewline(_:)):
+      activateSelectedItem()
+      return true
+    case #selector(moveUp(_:)):
+      moveSelection(by: -1)
+      return true
+    case #selector(moveDown(_:)):
+      moveSelection(by: 1)
+      return true
+    case #selector(cancelOperation(_:)):
+      window?.orderOut(self)
+      return true
+    default:
+      return false
+    }
+  }
+}
+
+// MARK: - NSTableViewDataSource
+
+extension TabSwitcherView: NSTableViewDataSource {
+  func numberOfRows(in tableView: NSTableView) -> Int {
+    filteredItems.count
+  }
+}
+
+// MARK: - NSTableViewDelegate
+
+extension TabSwitcherView: NSTableViewDelegate {
+  func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int) -> NSView? {
+    let identifier = NSUserInterfaceItemIdentifier("TabCell")
+    let cell = tableView.makeView(withIdentifier: identifier, owner: nil) as? TabSwitcherCell
+      ?? TabSwitcherCell(identifier: identifier)
+
+    let item = filteredItems[row]
+    cell.configure(title: item.title, subtitle: item.subtitle)
+
+    return cell
+  }
+}
+
+private extension TabSwitcherView {
+  func setupSubviews(placeholder: String, accessibilityHelp: String) {
+    effectView.translatesAutoresizingMaskIntoConstraints = false
+    addSubview(effectView)
+
+    let iconView = NSImageView(image: .with(symbolName: "magnifyingglass", pointSize: 16, weight: .light))
+    iconView.translatesAutoresizingMaskIntoConstraints = false
+    addSubview(iconView)
+
+    textField.placeholderString = placeholder
+    textField.setAccessibilityHelp(accessibilityHelp)
+    textField.delegate = self
+    textField.translatesAutoresizingMaskIntoConstraints = false
+    addSubview(textField)
+
+    let divider = NSBox()
+    divider.boxType = .separator
+    divider.translatesAutoresizingMaskIntoConstraints = false
+    addSubview(divider)
+
+    tableView.dataSource = self
+    tableView.delegate = self
+    tableView.doubleAction = #selector(tableViewDoubleClicked)
+    tableView.target = self
+    scrollView.documentView = tableView
+    scrollView.translatesAutoresizingMaskIntoConstraints = false
+    addSubview(scrollView)
+
+    addSubview(emptyLabel)
+
+    NSLayoutConstraint.activate([
+      effectView.leadingAnchor.constraint(equalTo: leadingAnchor),
+      effectView.trailingAnchor.constraint(equalTo: trailingAnchor),
+      effectView.topAnchor.constraint(equalTo: topAnchor),
+      effectView.bottomAnchor.constraint(equalTo: bottomAnchor),
+
+      iconView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Constants.padding + Constants.iconInset),
+      iconView.topAnchor.constraint(equalTo: topAnchor, constant: Constants.padding),
+      iconView.heightAnchor.constraint(equalToConstant: Constants.searchHeight - Constants.padding),
+      iconView.widthAnchor.constraint(equalToConstant: Constants.iconWidth),
+
+      textField.leadingAnchor.constraint(equalTo: iconView.trailingAnchor, constant: Constants.padding),
+      textField.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Constants.padding),
+      textField.centerYAnchor.constraint(equalTo: iconView.centerYAnchor),
+
+      divider.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Constants.padding),
+      divider.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Constants.padding),
+      divider.topAnchor.constraint(equalTo: topAnchor, constant: Constants.searchHeight + Constants.padding),
+
+      scrollView.leadingAnchor.constraint(equalTo: leadingAnchor),
+      scrollView.trailingAnchor.constraint(equalTo: trailingAnchor),
+      scrollView.topAnchor.constraint(equalTo: divider.bottomAnchor, constant: Constants.dividerSpacing),
+      scrollView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -Constants.padding),
+
+      emptyLabel.centerXAnchor.constraint(equalTo: scrollView.centerXAnchor),
+      emptyLabel.centerYAnchor.constraint(equalTo: scrollView.centerYAnchor),
+    ])
+  }
+
+  func filterItems() {
+    let query = textField.stringValue
+
+    if query.isEmpty {
+      filteredItems = allItems
+    } else {
+      filteredItems = allItems.filter {
+        $0.title.localizedCaseInsensitiveContains(query) || $0.subtitle.localizedCaseInsensitiveContains(query)
+      }
+    }
+
+    tableView.reloadData()
+    emptyLabel.isHidden = !filteredItems.isEmpty
+    selectRow(0)
+  }
+
+  func moveSelection(by delta: Int) {
+    guard !filteredItems.isEmpty else {
+      return
+    }
+
+    let current = max(tableView.selectedRow, 0)
+    let next = (current + delta + filteredItems.count) % filteredItems.count
+    selectRow(next)
+  }
+
+  func selectRow(_ row: Int) {
+    guard row >= 0, row < filteredItems.count else {
+      return
+    }
+
+    tableView.selectRowIndexes(IndexSet(integer: row), byExtendingSelection: false)
+    tableView.scrollRowToVisible(row)
+  }
+
+  func activateSelectedItem() {
+    let row = tableView.selectedRow
+
+    guard row >= 0, row < filteredItems.count else {
+      return
+    }
+
+    let item = filteredItems[row]
+    window?.orderOut(self)
+    item.handler()
+  }
+
+  @objc func tableViewDoubleClicked() {
+    let row = tableView.clickedRow
+
+    guard row >= 0, row < filteredItems.count else {
+      return
+    }
+
+    selectRow(row)
+    activateSelectedItem()
+  }
+}
+
+// MARK: - TabSwitcherCell
+
+private final class TabSwitcherCell: NSTableCellView {
+  private let titleLabel: NSTextField = {
+    let label = NSTextField(labelWithString: "")
+    label.font = .systemFont(ofSize: 13, weight: .regular)
+    label.lineBreakMode = .byTruncatingMiddle
+
+    return label
+  }()
+
+  private let subtitleLabel: NSTextField = {
+    let label = NSTextField(labelWithString: "")
+    label.font = .systemFont(ofSize: 11, weight: .regular)
+    label.textColor = .secondaryLabelColor
+    label.lineBreakMode = .byTruncatingHead
+
+    return label
+  }()
+
+  init(identifier: NSUserInterfaceItemIdentifier) {
+    super.init(frame: .zero)
+    self.identifier = identifier
+    self.textField = titleLabel
+
+    titleLabel.translatesAutoresizingMaskIntoConstraints = false
+    subtitleLabel.translatesAutoresizingMaskIntoConstraints = false
+    addSubview(titleLabel)
+    addSubview(subtitleLabel)
+
+    NSLayoutConstraint.activate([
+      titleLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 12),
+      titleLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
+
+      subtitleLabel.leadingAnchor.constraint(equalTo: titleLabel.trailingAnchor, constant: 8),
+      subtitleLabel.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -12),
+      subtitleLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
+    ])
+
+    titleLabel.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
+    subtitleLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+  }
+
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  func configure(title: String, subtitle: String) {
+    titleLabel.stringValue = title
+    subtitleLabel.stringValue = subtitle
+    subtitleLabel.isHidden = subtitle.isEmpty
+  }
+}

--- a/MarkEditMac/Modules/Sources/AppKitControls/TabSwitcher/TabSwitcherWindow.swift
+++ b/MarkEditMac/Modules/Sources/AppKitControls/TabSwitcher/TabSwitcherWindow.swift
@@ -1,0 +1,80 @@
+//
+//  TabSwitcherWindow.swift
+//
+//  Created by lamchau on 4/16/26.
+//
+
+import AppKit
+
+public struct TabSwitcherItem {
+  public let title: String
+  public let subtitle: String
+  public let handler: @MainActor () -> Void
+
+  public init(title: String, subtitle: String, handler: @escaping @MainActor () -> Void) {
+    self.title = title
+    self.subtitle = subtitle
+    self.handler = handler
+  }
+}
+
+public final class TabSwitcherWindow: NSWindow {
+  private enum Constants {
+    static let width: Double = 500
+    static let height: Double = 320
+    static let topOffset: Double = 100
+  }
+
+  public init(
+    effectViewType: NSView.Type,
+    relativeTo parentRect: CGRect,
+    placeholder: String,
+    accessibilityHelp: String,
+    emptyMessage: String,
+    items: [TabSwitcherItem],
+    initialSelection: Int = 0
+  ) {
+    let rect = CGRect(
+      x: parentRect.minX + (parentRect.width - Constants.width) * 0.5,
+      y: parentRect.minY + parentRect.height - Constants.height - Constants.topOffset,
+      width: Constants.width,
+      height: Constants.height
+    )
+
+    let view = TabSwitcherView(
+      effectViewType: effectViewType,
+      frame: rect,
+      placeholder: placeholder,
+      accessibilityHelp: accessibilityHelp,
+      emptyMessage: emptyMessage,
+      items: items,
+      initialSelection: initialSelection
+    )
+
+    super.init(
+      contentRect: rect,
+      styleMask: .borderless,
+      backing: .buffered,
+      defer: false
+    )
+
+    self.contentView = view
+    self.isMovableByWindowBackground = true
+    self.isOpaque = false
+    self.hasShadow = true
+    self.backgroundColor = .clear
+  }
+
+  override public var canBecomeKey: Bool {
+    true
+  }
+
+  override public func resignKey() {
+    super.resignKey()
+    orderOut(self)
+  }
+
+  override public func cancelOperation(_ sender: Any?) {
+    orderOut(self)
+  }
+}

--- a/MarkEditMac/Resources/Localizable.xcstrings
+++ b/MarkEditMac/Resources/Localizable.xcstrings
@@ -210,6 +210,9 @@
         }
       }
     },
+    "Always show tab bar" : {
+      "comment" : "Option to always show the tab bar even with a single tab"
+    },
     "Appearance:" : {
       "comment" : "Appearance for the app",
       "localizations" : {
@@ -1990,6 +1993,9 @@
         }
       }
     },
+    "No Matching Documents" : {
+      "comment" : "Empty state text when tab switcher filter matches nothing"
+    },
     "No versions match the specified condition." : {
       "comment" : "Alert title for no versions found",
       "localizations" : {
@@ -2740,6 +2746,9 @@
         }
       }
     },
+    "Switch to Document..." : {
+      "comment" : "Placeholder text for tab switcher window"
+    },
     "System" : {
       "comment" : "Follow the system appearance",
       "localizations" : {
@@ -3062,6 +3071,9 @@
           }
         }
       }
+    },
+    "Type to filter open documents, use arrow keys to navigate, press Enter to switch" : {
+      "comment" : "Help text for tab switcher window"
     },
     "Unfold" : {
       "comment" : "Phrase used in CodeMirror to unfold a piece of text",

--- a/MarkEditMac/Sources/Editor/Controllers/EditorViewController+TabSwitcher.swift
+++ b/MarkEditMac/Sources/Editor/Controllers/EditorViewController+TabSwitcher.swift
@@ -1,0 +1,68 @@
+//
+//  EditorViewController+TabSwitcher.swift
+//  MarkEditMac
+//
+//  Created by lamchau on 4/16/26.
+//
+
+import AppKit
+import AppKitControls
+import MarkEditKit
+
+extension EditorViewController {
+  @IBAction func showTabSwitcher(_ sender: Any?) {
+    guard !(NSApp.keyWindow is TabSwitcherWindow) else { return }
+
+    guard let parentRect = view.window?.frame else {
+      Logger.assertFail("Failed to retrieve window.frame to proceed")
+      return
+    }
+
+    let documents = NSDocumentController.shared.editorDocuments
+
+    guard !documents.isEmpty else {
+      return
+    }
+
+    if completionContext.isPanelVisible {
+      cancelCompletion()
+    }
+
+    let currentDocument = view.window?.windowController?.document as? EditorDocument
+    var initialSelection = 0
+
+    let items = documents.enumerated().map { index, document in
+      if document === currentDocument {
+        initialSelection = index
+      }
+
+      let title = document.displayName ?? ""
+      let subtitle = (document.fileURL?.deletingLastPathComponent().path as NSString?)?.abbreviatingWithTildeInPath ?? ""
+
+      return TabSwitcherItem(title: title, subtitle: subtitle) { [weak document] in
+        guard let window = document?.windowControllers.first?.window else {
+          return
+        }
+
+        window.makeKeyAndOrderFront(nil)
+
+        if let tabGroup = window.tabGroup {
+          tabGroup.selectedWindow = window
+        }
+      }
+    }
+
+    let window = TabSwitcherWindow(
+      effectViewType: AppDesign.modernEffectView,
+      relativeTo: parentRect,
+      placeholder: Localized.Document.tabSwitcherLabel,
+      accessibilityHelp: Localized.Document.tabSwitcherHelp,
+      emptyMessage: Localized.Document.tabSwitcherEmpty,
+      items: items,
+      initialSelection: initialSelection
+    )
+
+    window.appearance = view.effectiveAppearance
+    window.makeKeyAndOrderFront(sender)
+  }
+}

--- a/MarkEditMac/Sources/Editor/EditorWindow.swift
+++ b/MarkEditMac/Sources/Editor/EditorWindow.swift
@@ -46,6 +46,19 @@ final class EditorWindow: NSWindow {
     tabbingMode = AppPreferences.Window.tabbingMode
     titlebarAppearsTransparent = AppDesign.modernTitleBar
     reduceTransparency = AppDesign.reduceTransparency
+
+    if AppPreferences.Window.alwaysShowTabBar {
+      DispatchQueue.main.async { [weak self] in
+        self?.setTabBarVisible(true)
+      }
+    }
+  }
+
+  func setTabBarVisible(_ visible: Bool) {
+    guard let tabGroup = tabGroup else { return }
+    if tabGroup.isTabBarVisible != visible {
+      toggleTabBar(nil)
+    }
   }
 
   override func layoutIfNeeded() {

--- a/MarkEditMac/Sources/Main/AppPreferences.swift
+++ b/MarkEditMac/Sources/Main/AppPreferences.swift
@@ -226,6 +226,15 @@ enum AppPreferences {
       }
     }
 
+    @Storage(key: "window.always-show-tab-bar", defaultValue: false)
+    static var alwaysShowTabBar: Bool {
+      didSet {
+        performUpdates { editor in
+          (editor.view.window as? EditorWindow)?.setTabBarVisible(alwaysShowTabBar)
+        }
+      }
+    }
+
     @Storage(key: "window.reduce-transparency", defaultValue: false)
     static var reduceTransparency: Bool {
       didSet {

--- a/MarkEditMac/Sources/Main/AppResources.swift
+++ b/MarkEditMac/Sources/Main/AppResources.swift
@@ -91,6 +91,9 @@ enum Localized {
     static let newDocument = String(localized: "New Document", comment: "Menu item: create a new document")
     static let gotoLineLabel = String(localized: "Go to Line", comment: "Placeholder text for goto line window")
     static let gotoLineHelp = String(localized: "Enter the line number and hit return", comment: "Help text for goto line window")
+    static let tabSwitcherLabel = String(localized: "Switch to Document...", comment: "Placeholder text for tab switcher window")
+    static let tabSwitcherHelp = String(localized: "Type to filter open documents, use arrow keys to navigate, press Enter to switch", comment: "Help text for tab switcher window")
+    static let tabSwitcherEmpty = String(localized: "No Matching Documents", comment: "Empty state text when tab switcher filter matches nothing")
     static let fileExtension = String(localized: "File Extension:", comment: "Label for save panel accessory view (shorter than 'Filename Extension' to avoid save panel layout issues)")
     static let textEncoding = String(localized: "Text Encoding:", comment: "Label for save panel accessory view")
     static let showHiddenFiles = String(localized: "Show Hidden Files", comment: "Label for save panel accessory view")
@@ -196,6 +199,7 @@ enum Localized {
     static let automatic = String(localized: "Automatic", comment: "Automatic window tabbing mode")
     static let preferred = String(localized: "Preferred", comment: "Preferred window tabbing mode")
     static let disallowed = String(localized: "Disallowed", comment: "Disallowed window tabbing mode")
+    static let alwaysShowTabBar = String(localized: "Always show tab bar", comment: "Option to always show the tab bar even with a single tab")
     static let reduceTransparencyLabel = String(localized: "Reduce Transparency:", comment: "Label for the option to reduce window transparency")
     static let reduceTransparencyDescription = String(localized: "Remove the toolbar blur", comment: "Explanation for the option to reduce window transparency")
   }

--- a/MarkEditMac/Sources/Settings/WindowSettingsView.swift
+++ b/MarkEditMac/Sources/Settings/WindowSettingsView.swift
@@ -12,6 +12,7 @@ import SettingsUI
 struct WindowSettingsView: View {
   @State private var toolbarMode = AppPreferences.Window.toolbarMode
   @State private var tabbingMode = AppPreferences.Window.tabbingMode
+  @State private var alwaysShowTabBar = AppPreferences.Window.alwaysShowTabBar
   @State private var reduceTransparency = AppPreferences.Window.reduceTransparency
 
   var body: some View {
@@ -36,6 +37,12 @@ struct WindowSettingsView: View {
           AppPreferences.Window.tabbingMode = tabbingMode
         }
         .formMenuPicker()
+
+        Toggle(Localized.Settings.alwaysShowTabBar, isOn: $alwaysShowTabBar)
+          .onChange(of: alwaysShowTabBar) {
+            AppPreferences.Window.alwaysShowTabBar = alwaysShowTabBar
+          }
+          .disabled(tabbingMode == .disallowed)
       }
 
       Section {

--- a/MarkEditMac/mul.lproj/Main.xcstrings
+++ b/MarkEditMac/mul.lproj/Main.xcstrings
@@ -3555,6 +3555,18 @@
         }
       }
     },
+    "tsw-Tb-SwT.title" : {
+      "comment" : "Class = \"NSMenuItem\"; title = \"Switch Document…\"; ObjectID = \"tsw-Tb-SwT\";",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Switch Document…"
+          }
+        }
+      }
+    },
     "Tuy-2U-frg.title" : {
       "comment" : "Class = \"NSMenu\"; title = \"Open In…\"; ObjectID = \"Tuy-2U-frg\";",
       "extractionState" : "extracted_with_value",


### PR DESCRIPTION
# Improve tab UX
 * Tab switcher: floating search panel to fuzzy filter and switch between open documents. Modeled on the existing GotoLine window pattern. Keyboard navigation with Up/Down/Enter/Escape.
* Always show tab bar: new Window preference that keeps the tab bar visible even with a single tab, enabling drag to merge workflows (similar to iTerm).
  * Without this, the only way to merge 2 standalone windows is to create 2 empty documents (force tab bar to show), drag, and close the new _Untitled_ docs)

<img width="2304" height="2168" alt="image" src="https://github.com/user-attachments/assets/5ebed8c0-a766-47de-a99f-6c84c76d580a" />
