### PR TITLE
Use baseURL for image loader

### DIFF
--- a/MarkEditMac/Sources/Editor/Controllers/EditorViewController.swift
+++ b/MarkEditMac/Sources/Editor/Controllers/EditorViewController.swift
@@ -161,7 +161,7 @@ final class EditorViewController: NSViewController {
 
     let chunkLoader = EditorChunkLoader()
     let imageLoader = EditorImageLoader { [weak self] in
-      self?.document?.folderURL
+      self?.document?.baseURL
     }
 
     config.setURLSchemeHandler(chunkLoader, forURLScheme: EditorChunkLoader.scheme)


### PR DESCRIPTION
It didn't work for `*.textbundle` containers.