### PR TITLE
Change "Reuse Pool" to "Preloader"

### DIFF
--- a/CoreEditor/src/bridge/web/core.ts
+++ b/CoreEditor/src/bridge/web/core.ts
@@ -5,7 +5,6 @@ import {
   ReadableContentPair,
   ReplaceGranularity,
   resetEditor,
-  clearEditor,
   getEditorState,
   getEditorText,
   getReadableContentPair,
@@ -24,7 +23,6 @@ import {
  */
 export interface WebModuleCore extends WebModule {
   resetEditor({ text, selectionRange }: { text: string; selectionRange?: SelectionRange }): void;
-  clearEditor(): void;
   getEditorState(): { hasFocus: boolean; hasSelection: boolean };
   getEditorText(): string;
   getReadableContentPair(): ReadableContentPair;
@@ -39,10 +37,6 @@ export interface WebModuleCore extends WebModule {
 export class WebModuleCoreImpl implements WebModuleCore {
   resetEditor({ text, selectionRange }: { text: string; selectionRange?: SelectionRange }): void {
     resetEditor(text, selectionRange);
-  }
-
-  clearEditor(): void {
-    clearEditor();
   }
 
   getEditorState(): { hasFocus: boolean; hasSelection: boolean } {

--- a/CoreEditor/src/common/store.ts
+++ b/CoreEditor/src/common/store.ts
@@ -14,7 +14,6 @@ export const globalState: {
 };
 
 export const editingState = {
-  isIdle: false,
   hasSelection: false,
   compositionEnded: true,
 };

--- a/CoreEditor/src/core.ts
+++ b/CoreEditor/src/core.ts
@@ -1,7 +1,7 @@
 import { EditorView } from '@codemirror/view';
 import { EditorSelection, EditorState } from '@codemirror/state';
 import { extensions } from './extensions';
-import { globalState, editingState } from './common/store';
+import { globalState } from './common/store';
 import { almostEqual, afterDomUpdate, getViewportScale, isReleaseMode, isMotionReduced } from './common/utils';
 
 import hasSelection from './modules/selection/hasSelection';
@@ -63,9 +63,6 @@ export enum ReplaceGranularity {
  * Reset the editor to the initial state.
  */
 export function resetEditor(initialContent: string, selectionRange?: SelectionRange) {
-  // Idle state change should always go first
-  editingState.isIdle = false;
-
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   if (typeof window.editor?.destroy === 'function') {
     window.editor.destroy();
@@ -171,19 +168,6 @@ export function resetEditor(initialContent: string, selectionRange?: SelectionRa
 
   // For user scripts, notify the editor is ready
   editorReadyListeners().forEach(listener => listener(editor));
-}
-
-/**
- * Clear the editor, set the content to empty.
- */
-export function clearEditor() {
-  // Idle state change should always go first
-  editingState.isIdle = true;
-
-  const editor = window.editor;
-  editor.dispatch({
-    changes: { from: 0, to: editor.state.doc.length, insert: '' },
-  });
 }
 
 export function getEditorState() {

--- a/CoreEditor/src/modules/input/index.ts
+++ b/CoreEditor/src/modules/input/index.ts
@@ -103,11 +103,6 @@ export function interceptInputs() {
  */
 export function observeChanges() {
   return EditorView.updateListener.of(update => {
-    // Ignore all events when the editor is idle
-    if (editingState.isIdle && update.state.doc.length === 0) {
-      return;
-    }
-
     if (update.docChanged) {
       // This should be called before updating the native view
       setHistoryExplictlyMoved(update);

--- a/MarkEdit.xcodeproj/project.pbxproj
+++ b/MarkEdit.xcodeproj/project.pbxproj
@@ -66,7 +66,7 @@
 		8767BBB5295AD62700BFACAE /* EditorReplaceButtons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8767BBB4295AD62700BFACAE /* EditorReplaceButtons.swift */; };
 		8769BABE2C65F9D400EDA0A6 /* AppRuntimeConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8769BABD2C65F9D400EDA0A6 /* AppRuntimeConfig.swift */; };
 		876D70872E7A8E9D00E308A4 /* AppIcon.icon in Resources */ = {isa = PBXBuildFile; fileRef = 876D70862E7A8E9D00E308A4 /* AppIcon.icon */; };
-		8772E385294AC60D00111E83 /* EditorReusePool.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8772E384294AC60D00111E83 /* EditorReusePool.swift */; };
+		8772E385294AC60D00111E83 /* EditorPreloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8772E384294AC60D00111E83 /* EditorPreloader.swift */; };
 		8775A77B29867012005867BF /* FontPicker in Frameworks */ = {isa = PBXBuildFile; productRef = 8775A77A29867012005867BF /* FontPicker */; };
 		877A6D802C77248A001EC516 /* NSPopover+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877A6D7F2C77248A001EC516 /* NSPopover+Extension.swift */; };
 		877B965D2C63815000186414 /* AppHotKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877B965C2C63815000186414 /* AppHotKeys.swift */; };
@@ -100,7 +100,6 @@
 		87BE2E342DF9B5C000A51CF4 /* Bundle+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87BE2E332DF9B5BB00A51CF4 /* Bundle+Extension.swift */; };
 		87BEF30129A88F6800596E17 /* AppCustomization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87BEF30029A88F6800596E17 /* AppCustomization.swift */; };
 		87CC48FD29CC01E100BE1441 /* TextBundle in Frameworks */ = {isa = PBXBuildFile; productRef = 87CC48FC29CC01E100BE1441 /* TextBundle */; };
-		CC000020300000000000FD01 /* FileDrop in Frameworks */ = {isa = PBXBuildFile; productRef = CC000020300000000000FD02 /* FileDrop */; };
 		87D7F0212DE8725100985ABF /* EditorImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87D7F0202DE8724A00985ABF /* EditorImageLoader.swift */; };
 		87D9322E2A925C6700B20D84 /* EditorReplaceTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87D9322D2A925C6700B20D84 /* EditorReplaceTextField.swift */; };
 		87DCB6202B284AAD00A3056F /* AppHacks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87DCB61F2B284AAD00A3056F /* AppHacks.swift */; };
@@ -116,6 +115,7 @@
 		CC000003300000000000001A /* AppDelegate+ClosedTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC000003300000000000001B /* AppDelegate+ClosedTab.swift */; };
 		CC000004300000000000001A /* EditorSelectionHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC000004300000000000001B /* EditorSelectionHistory.swift */; };
 		CC000006300000000000001A /* EditorClosedTabHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC000006300000000000001B /* EditorClosedTabHistory.swift */; };
+		CC000020300000000000FD01 /* FileDrop in Frameworks */ = {isa = PBXBuildFile; productRef = CC000020300000000000FD02 /* FileDrop */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -215,7 +215,7 @@
 		8767BBB4295AD62700BFACAE /* EditorReplaceButtons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorReplaceButtons.swift; sourceTree = "<group>"; };
 		8769BABD2C65F9D400EDA0A6 /* AppRuntimeConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRuntimeConfig.swift; sourceTree = "<group>"; };
 		876D70862E7A8E9D00E308A4 /* AppIcon.icon */ = {isa = PBXFileReference; lastKnownFileType = folder.iconcomposer.icon; path = AppIcon.icon; sourceTree = "<group>"; };
-		8772E384294AC60D00111E83 /* EditorReusePool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorReusePool.swift; sourceTree = "<group>"; };
+		8772E384294AC60D00111E83 /* EditorPreloader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorPreloader.swift; sourceTree = "<group>"; };
 		877A6D7F2C77248A001EC516 /* NSPopover+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSPopover+Extension.swift"; sourceTree = "<group>"; };
 		877B965C2C63815000186414 /* AppHotKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppHotKeys.swift; sourceTree = "<group>"; };
 		877D77C92DFA76E50086180B /* AppDesign.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDesign.swift; sourceTree = "<group>"; };
@@ -598,7 +598,7 @@
 			children = (
 				870A51B8294702AF0095C7EB /* EditorDocument.swift */,
 				CC000002300000000000001B /* EditorDocument+ClosedTab.swift */,
-				8772E384294AC60D00111E83 /* EditorReusePool.swift */,
+				8772E384294AC60D00111E83 /* EditorPreloader.swift */,
 				8725E07F2977EEB3006A4961 /* EditorToolbarItems.swift */,
 				878AABE82CB111410081C5E1 /* EditorMenuItem.swift */,
 			);
@@ -804,7 +804,7 @@
 				87BDF6E42976C97100548079 /* EditorViewController+GotoLine.swift in Sources */,
 				874BE6FB29BB5804002F83BA /* AppIntent+Extension.swift in Sources */,
 				87F2B5F429ACF56E0027103E /* EditorViewController+Completion.swift in Sources */,
-				8772E385294AC60D00111E83 /* EditorReusePool.swift in Sources */,
+				8772E385294AC60D00111E83 /* EditorPreloader.swift in Sources */,
 				8709C69E29B4412F009EABB5 /* AssistantSettingsView.swift in Sources */,
 				877A6D802C77248A001EC516 /* NSPopover+Extension.swift in Sources */,
 				874BE70229BB5889002F83BA /* GetFileContentIntent.swift in Sources */,
@@ -1378,13 +1378,13 @@
 			isa = XCSwiftPackageProductDependency;
 			productName = TextBundle;
 		};
-		CC000020300000000000FD02 /* FileDrop */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = FileDrop;
-		};
 		87EB9900295755DA00A56B97 /* MarkEditCore */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = MarkEditCore;
+		};
+		CC000020300000000000FD02 /* FileDrop */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = FileDrop;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/MarkEditKit/Sources/Bridge/Web/Generated/WebBridgeCore.swift
+++ b/MarkEditKit/Sources/Bridge/Web/Generated/WebBridgeCore.swift
@@ -32,10 +32,6 @@ public final class WebBridgeCore {
     webView?.invoke(path: "webModules.core.resetEditor", message: message, completion: completion)
   }
 
-  public func clearEditor(completion: ((Result<Void, WKWebView.InvokeError>) -> Void)? = nil) {
-    webView?.invoke(path: "webModules.core.clearEditor", completion: completion)
-  }
-
   public func getEditorState() async throws -> WebBridgeCoreGetEditorStateReturnType {
     guard let webView else {
       throw WKWebView.InvokeError.unexpectedNil

--- a/MarkEditMac/Sources/Editor/Controllers/EditorViewController.swift
+++ b/MarkEditMac/Sources/Editor/Controllers/EditorViewController.swift
@@ -334,18 +334,6 @@ extension EditorViewController {
     bridge.core.insertText(text: text, from: 0, to: 0)
   }
 
-  func clearEditor() {
-    updateTextFinderMode(.hidden, searchTerm: "")
-
-    // The delay is in theory not necessary,
-    // because autosave happens before closing the window.
-    //
-    // Just in case someone introduces race conditions.
-    DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-      self.bridge.core.clearEditor()
-    }
-  }
-
   func resetEditor() {
     guard hasFinishedLoading, let textContent = document?.stringValue else {
       return

--- a/MarkEditMac/Sources/Editor/EditorWindowController.swift
+++ b/MarkEditMac/Sources/Editor/EditorWindowController.swift
@@ -45,7 +45,7 @@ final class EditorWindowController: NSWindowController, NSWindowDelegate {
 
     // The shared "field editor" tends to hold focus,
     // manually resign the focus to ensure cmd-f responds correctly.
-    for editor in EditorReusePool.shared.viewControllers() where editor !== editorViewController {
+    for editor in EditorPreloader.shared.viewControllers() where editor !== editorViewController {
       editor.resignFindPanelFocus()
     }
 
@@ -85,10 +85,6 @@ final class EditorWindowController: NSWindowController, NSWindowDelegate {
   func windowShouldClose(_ sender: NSWindow) -> Bool {
     captureTabIndex(for: sender)
     return true
-  }
-
-  func windowWillClose(_ notification: Notification) {
-    editorViewController?.clearEditor()
   }
 
   // Refresh titlebar appearance after fullscreen transitions,

--- a/MarkEditMac/Sources/Editor/Models/EditorDocument.swift
+++ b/MarkEditMac/Sources/Editor/Models/EditorDocument.swift
@@ -100,7 +100,7 @@ final class EditorDocument: NSDocument {
     }
 
     // Note hostViewController is a weak reference, it must be strongly retained first
-    let contentVC = EditorReusePool.shared.dequeueViewController()
+    let contentVC = EditorPreloader.shared.takeViewController()
     windowController.contentViewController = contentVC
 
     // Restore the autosaved window frame, which relies on windowFrameAutosaveName

--- a/MarkEditMac/Sources/Editor/Models/EditorPreloader.swift
+++ b/MarkEditMac/Sources/Editor/Models/EditorPreloader.swift
@@ -1,5 +1,5 @@
 //
-//  EditorReusePool.swift
+//  EditorPreloader.swift
 //  MarkEditMac
 //
 //  Created by cyan on 12/15/22.
@@ -10,11 +10,11 @@ import WebKit
 import MarkEditKit
 
 /**
- Reuse pool for editors to keep WebViews in memory.
+ Preloads an `EditorViewController` so the next document can open without paying the WebView load cost.
  */
 @MainActor
-final class EditorReusePool {
-  static let shared = EditorReusePool()
+final class EditorPreloader {
+  static let shared = EditorPreloader()
 
   func warmUp() {
     // Start loading an editor early so prepareViewController() can return faster.
@@ -32,7 +32,7 @@ final class EditorReusePool {
   }
 
   /// Ensure the preloaded controller has finished loading,
-  /// call this before ``dequeueViewController()`` to guarantee readiness.
+  /// call this before ``takeViewController()`` to guarantee readiness.
   func prepareViewController() async {
     if preloadedController == nil {
       preloadedController = EditorViewController()
@@ -41,7 +41,7 @@ final class EditorReusePool {
     await preloadedController?.waitUntilLoaded()
   }
 
-  func dequeueViewController() -> EditorViewController {
+  func takeViewController() -> EditorViewController {
     let controller = preloadedController ?? EditorViewController()
     preloadedController = EditorViewController(preloadDelay: 0.2)
 

--- a/MarkEditMac/Sources/Main/AppDocumentController.swift
+++ b/MarkEditMac/Sources/Main/AppDocumentController.swift
@@ -62,8 +62,8 @@ final class AppDocumentController: NSDocumentController {
     }
 
     Task { @MainActor in
-      // Ensure the reuse pool has a fully loaded editor before opening the document
-      await EditorReusePool.shared.prepareViewController()
+      // Ensure the preloader has a fully loaded editor before opening the document
+      await EditorPreloader.shared.prepareViewController()
 
       super.openDocument(
         withContentsOf: url,

--- a/MarkEditMac/Sources/Main/AppPreferences.swift
+++ b/MarkEditMac/Sources/Main/AppPreferences.swift
@@ -425,7 +425,7 @@ extension NSWindow.TabbingMode: @retroactive Codable {}
 private extension AppPreferences {
   static func performUpdates(action: @escaping (EditorViewController) -> Void) {
     Task { @MainActor in
-      for editor in EditorReusePool.shared.viewControllers() {
+      for editor in EditorPreloader.shared.viewControllers() {
         action(editor)
       }
     }

--- a/MarkEditMac/Sources/Main/AppTheme.swift
+++ b/MarkEditMac/Sources/Main/AppTheme.swift
@@ -32,7 +32,7 @@ struct AppTheme {
   /// Trigger theme update for all editors.
   @MainActor
   func updateAppearance(animateChanges: Bool = false) {
-    EditorReusePool.shared.viewControllers().forEach {
+    EditorPreloader.shared.viewControllers().forEach {
       $0.setTheme(self, animated: animateChanges)
     }
   }

--- a/MarkEditMac/Sources/Main/Application/AppDelegate.swift
+++ b/MarkEditMac/Sources/Main/Application/AppDelegate.swift
@@ -56,7 +56,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
   private var settingsWindowController: NSWindowController?
 
   func applicationWillFinishLaunching(_ notification: Notification) {
-    EditorReusePool.shared.warmUp()
+    EditorPreloader.shared.warmUp()
   }
 
   func applicationDidFinishLaunching(_ notification: Notification) {

--- a/MarkEditMac/Sources/Shortcuts/Extensions/AppIntent+Extension.swift
+++ b/MarkEditMac/Sources/Shortcuts/Extensions/AppIntent+Extension.swift
@@ -11,7 +11,7 @@ import AppKit
 extension AppIntent {
   /// Returns the current active editor, or nil if not applicable.
   @MainActor var currentEditor: EditorViewController? {
-    let orderedControllers = EditorReusePool.shared.viewControllers().sorted {
+    let orderedControllers = EditorPreloader.shared.viewControllers().sorted {
       let lhs = $0.view.window?.orderedIndex ?? .max
       let rhs = $1.view.window?.orderedIndex ?? .max
       return lhs < rhs


### PR DESCRIPTION
The existence of `clearEditor` was mainly because at some point editors were reused.

Right now, we only preload an editor, nothing is reused or stale.