### PR TITLE
Disable window occlusion detection

### DIFF
--- a/MarkEditCore/Sources/Extensions/WebKit+Extension.swift
+++ b/MarkEditCore/Sources/Extensions/WebKit+Extension.swift
@@ -1,10 +1,19 @@
 //
-//  WKWebViewConfiguration+Extension.swift
+//  WebKit+Extension.swift
 //
 //  Created by cyan on 3/29/26.
 //
 
 import WebKit
+
+public extension WKWebView {
+  /// Keep rendering and timers active when the window is occluded by other windows.
+  func disableWindowOcclusionDetection() {
+    if !setBoolValue(false, forSelector: "_setWindowOcclusionDetectionEnabled:") {
+      assertionFailure("Failed to call _setWindowOcclusionDetectionEnabled:")
+    }
+  }
+}
 
 public extension WKWebViewConfiguration {
   func enablePerformanceFlags() {
@@ -51,6 +60,7 @@ public extension WKWebViewConfiguration {
 // MARK: - WebKitConfigSPI
 
 public protocol WebKitConfigSPI: NSObject {}
+extension WKWebView: WebKitConfigSPI {}
 extension WKWebViewConfiguration: WebKitConfigSPI {}
 extension WKPreferences: WebKitConfigSPI {}
 

--- a/MarkEditMac/Sources/Editor/Controllers/EditorViewController.swift
+++ b/MarkEditMac/Sources/Editor/Controllers/EditorViewController.swift
@@ -177,6 +177,7 @@ final class EditorViewController: NSViewController {
     webView.allowsMagnification = true
     webView.uiDelegate = self
     webView.actionDelegate = self
+    webView.disableWindowOcclusionDetection()
 
     let theme = AppTheme.current.editorTheme
     DispatchQueue.global(qos: .userInitiated).async {

--- a/PreviewExtension/PreviewViewController.swift
+++ b/PreviewExtension/PreviewViewController.swift
@@ -36,6 +36,7 @@ final class PreviewViewController: NSViewController, QLPreviewingController {
 
     let webView = WebView(frame: .zero, configuration: config)
     webView.allowsMagnification = true
+    webView.disableWindowOcclusionDetection()
 
     return webView
   }()


### PR DESCRIPTION
Learned from Raycast's 2.0 technical deep dive: https://www.raycast.com/blog/a-technical-deep-dive-into-the-new-raycast

I tested this and it looks completely no difference at all, just a nice to have thing.