### PR TITLE
Add waitUntilEditorReset to avoid blank flash

### DIFF
--- a/CoreEditor/src/@codegen/swift-web-module.mustache
+++ b/CoreEditor/src/@codegen/swift-web-module.mustache
@@ -44,7 +44,7 @@ public final class {{moduleName}} {
       throw WKWebView.InvokeError.unexpectedNil
     }
 
-    return try await webView.invoke(path: "webModules.{{customTags.invokePath}}.{{methodName}}"{{#parameters.length}}, message: message{{/parameters.length}})
+    return try await webView.invoke(path: "webModules.{{customTags.invokePath}}.{{methodName}}"{{#parameters.length}}, message: message{{/parameters.length}}{{#method.isAsync}}, callAsync: true{{/method.isAsync}})
     {{/returnType}}
     {{^returnType}}
     webView?.invoke(path: "webModules.{{customTags.invokePath}}.{{methodName}}", {{#parameters.length}}message: message, {{/parameters.length}}completion: completion)

--- a/CoreEditor/src/bridge/web/core.ts
+++ b/CoreEditor/src/bridge/web/core.ts
@@ -22,7 +22,7 @@ import {
  * @overrideModuleName WebBridgeCore
  */
 export interface WebModuleCore extends WebModule {
-  resetEditor({ text, selectionRange }: { text: string; selectionRange?: SelectionRange }): void;
+  resetEditor({ text, selectionRange }: { text: string; selectionRange?: SelectionRange }): Promise<boolean>;
   getEditorState(): { hasFocus: boolean; hasSelection: boolean };
   getEditorText(): string;
   getReadableContentPair(): ReadableContentPair;
@@ -35,8 +35,8 @@ export interface WebModuleCore extends WebModule {
 }
 
 export class WebModuleCoreImpl implements WebModuleCore {
-  resetEditor({ text, selectionRange }: { text: string; selectionRange?: SelectionRange }): void {
-    resetEditor(text, selectionRange);
+  resetEditor({ text, selectionRange }: { text: string; selectionRange?: SelectionRange }): Promise<boolean> {
+    return resetEditor(text, selectionRange);
   }
 
   getEditorState(): { hasFocus: boolean; hasSelection: boolean } {

--- a/CoreEditor/src/core.ts
+++ b/CoreEditor/src/core.ts
@@ -62,7 +62,7 @@ export enum ReplaceGranularity {
 /**
  * Reset the editor to the initial state.
  */
-export function resetEditor(initialContent: string, selectionRange?: SelectionRange) {
+export async function resetEditor(initialContent: string, selectionRange?: SelectionRange): Promise<boolean> {
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   if (typeof window.editor?.destroy === 'function') {
     window.editor.destroy();
@@ -169,6 +169,24 @@ export function resetEditor(initialContent: string, selectionRange?: SelectionRa
 
   // For user scripts, notify the editor is ready
   editorReadyListeners().forEach(listener => listener(editor));
+
+  // Wait for the first paint: rAF when foregrounded, setTimeout as a fallback when throttled
+  await new Promise<void>(resolve => {
+    let settled = false;
+    const unblockWaiting = () => {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      resolve();
+    };
+
+    requestAnimationFrame(unblockWaiting);
+    afterDomUpdate(unblockWaiting);
+  });
+
+  return true;
 }
 
 export function getEditorState() {

--- a/CoreEditor/test/core.test.ts
+++ b/CoreEditor/test/core.test.ts
@@ -78,52 +78,52 @@ describe('resetEditor selection', () => {
     document.body.innerHTML = '';
   });
 
-  test('without selection range, cursor is at 0', () => {
-    resetEditor('Hello, World!');
+  test('without selection range, cursor is at 0', async () => {
+    await resetEditor('Hello, World!');
     const sel = window.editor.state.selection.main;
     expect(sel.anchor).toBe(0);
     expect(sel.head).toBe(0);
   });
 
-  test('with valid selection range', () => {
-    resetEditor('Hello, World!', { anchor: 7 as CodeGen_Int, head: 12 as CodeGen_Int });
+  test('with valid selection range', async () => {
+    await resetEditor('Hello, World!', { anchor: 7 as CodeGen_Int, head: 12 as CodeGen_Int });
     const sel = window.editor.state.selection.main;
     expect(sel.anchor).toBe(7);
     expect(sel.head).toBe(12);
   });
 
-  test('with cursor position (anchor equals head)', () => {
-    resetEditor('Hello, World!', { anchor: 5 as CodeGen_Int, head: 5 as CodeGen_Int });
+  test('with cursor position (anchor equals head)', async () => {
+    await resetEditor('Hello, World!', { anchor: 5 as CodeGen_Int, head: 5 as CodeGen_Int });
     const sel = window.editor.state.selection.main;
     expect(sel.anchor).toBe(5);
     expect(sel.head).toBe(5);
   });
 
-  test('selection range exceeding document length is clamped', () => {
+  test('selection range exceeding document length is clamped', async () => {
     const content = 'Short';
-    resetEditor(content, { anchor: 100 as CodeGen_Int, head: 200 as CodeGen_Int });
+    await resetEditor(content, { anchor: 100 as CodeGen_Int, head: 200 as CodeGen_Int });
     const sel = window.editor.state.selection.main;
     expect(sel.anchor).toBe(content.length);
     expect(sel.head).toBe(content.length);
   });
 
-  test('negative selection range is clamped to 0', () => {
-    resetEditor('Hello', { anchor: -5 as CodeGen_Int, head: -1 as CodeGen_Int });
+  test('negative selection range is clamped to 0', async () => {
+    await resetEditor('Hello', { anchor: -5 as CodeGen_Int, head: -1 as CodeGen_Int });
     const sel = window.editor.state.selection.main;
     expect(sel.anchor).toBe(0);
     expect(sel.head).toBe(0);
   });
 
-  test('empty document with selection range clamps to 0', () => {
-    resetEditor('', { anchor: 10 as CodeGen_Int, head: 20 as CodeGen_Int });
+  test('empty document with selection range clamps to 0', async () => {
+    await resetEditor('', { anchor: 10 as CodeGen_Int, head: 20 as CodeGen_Int });
     const sel = window.editor.state.selection.main;
     expect(sel.anchor).toBe(0);
     expect(sel.head).toBe(0);
   });
 
-  test('document content is preserved', () => {
+  test('document content is preserved', async () => {
     const content = 'Hello, MarkEdit!';
-    resetEditor(content, { anchor: 0 as CodeGen_Int, head: 5 as CodeGen_Int });
+    await resetEditor(content, { anchor: 0 as CodeGen_Int, head: 5 as CodeGen_Int });
     expect(window.editor.state.doc.toString()).toBe(content);
   });
 });
@@ -152,32 +152,32 @@ describe('performTextDrop', () => {
     });
   }
 
-  test('inserts text at the drop cursor position', () => {
-    resetEditor('Hello, World!');
+  test('inserts text at the drop cursor position', async () => {
+    await resetEditor('Hello, World!');
     fakeDropCursor(7);
 
     performTextDrop('there ');
     expect(window.editor.state.doc.toString()).toBe('Hello, there World!');
   });
 
-  test('moves the caret to after the inserted text', () => {
-    resetEditor('Hello, World!');
+  test('moves the caret to after the inserted text', async () => {
+    await resetEditor('Hello, World!');
     fakeDropCursor(7);
 
     performTextDrop('there ');
     expect(window.editor.state.selection.main.head).toBe(13);
   });
 
-  test('falls back to replacing the selection when no drop cursor is present', () => {
-    resetEditor('Hello, World!');
+  test('falls back to replacing the selection when no drop cursor is present', async () => {
+    await resetEditor('Hello, World!');
     window.editor.dispatch({ selection: EditorSelection.range(7, 12) });
 
     performTextDrop('Earth');
     expect(window.editor.state.doc.toString()).toBe('Hello, Earth!');
   });
 
-  test('falls back when posAtCoords returns null', () => {
-    resetEditor('Hello, World!');
+  test('falls back when posAtCoords returns null', async () => {
+    await resetEditor('Hello, World!');
     fakeDropCursor(null);
     window.editor.dispatch({ selection: EditorSelection.range(7, 12) });
 

--- a/MarkEditKit/Sources/Bridge/Web/Generated/WebBridgeCore.swift
+++ b/MarkEditKit/Sources/Bridge/Web/Generated/WebBridgeCore.swift
@@ -18,7 +18,7 @@ public final class WebBridgeCore {
     self.webView = webView
   }
 
-  public func resetEditor(text: String, selectionRange: SelectionRange?, completion: ((Result<Void, WKWebView.InvokeError>) -> Void)? = nil) {
+  public func resetEditor(text: String, selectionRange: SelectionRange?) async throws -> Bool {
     struct Message: Encodable {
       let text: String
       let selectionRange: SelectionRange?
@@ -29,7 +29,11 @@ public final class WebBridgeCore {
       selectionRange: selectionRange
     )
 
-    webView?.invoke(path: "webModules.core.resetEditor", message: message, completion: completion)
+    guard let webView else {
+      throw WKWebView.InvokeError.unexpectedNil
+    }
+
+    return try await webView.invoke(path: "webModules.core.resetEditor", message: message, callAsync: true)
   }
 
   public func getEditorState() async throws -> WebBridgeCoreGetEditorStateReturnType {

--- a/MarkEditKit/Sources/Extensions/WKWebView+Extension.swift
+++ b/MarkEditKit/Sources/Extensions/WKWebView+Extension.swift
@@ -81,13 +81,18 @@ extension WKWebView {
 
   func invoke<SuccessResult: Decodable>(
     path: String,
-    message: Encodable = Message()
+    message: Encodable = Message(),
+    callAsync: Bool = false
   ) async throws -> SuccessResult {
     let script = script(for: path, message: message)
     let value: Any?
 
     do {
-      value = try await evaluateJavaScript(script)
+      if callAsync {
+        value = try await callAsyncJavaScript("return await \(script)", contentWorld: .page)
+      } else {
+        value = try await evaluateJavaScript(script)
+      }
     } catch {
       Logger.log(.error, error.localizedDescription)
       throw InvokeError.evaluateError(path: path, error: error)

--- a/MarkEditMac/Sources/Editor/Controllers/EditorViewController.swift
+++ b/MarkEditMac/Sources/Editor/Controllers/EditorViewController.swift
@@ -25,6 +25,7 @@ final class EditorViewController: NSViewController {
   var mouseExitedWindow = false
   var nativeSearchQueryChanged = false
   var bottomPanelHeight: Double = 0
+  var pendingResetCount: Int = 0
   var initialContent: String?
   var webBackgroundColor = AppPreferences.Window.cachedBackgroundColor?.nsColor
   var localEventMonitor: Any?
@@ -228,6 +229,7 @@ final class EditorViewController: NSViewController {
 
   // For CoreEditor preload
   private var loadingContinuations = [CheckedContinuation<Void, Never>]()
+  private var resetContinuations = [CheckedContinuation<Void, Never>]()
 
   deinit {
     if let monitor = localEventMonitor {
@@ -323,6 +325,16 @@ extension EditorViewController {
     }
   }
 
+  func waitUntilEditorReset() async {
+    guard pendingResetCount > 0 else {
+      return
+    }
+
+    await withCheckedContinuation {
+      resetContinuations.append($0)
+    }
+  }
+
   func prepareInitialContent(_ text: String) {
     if hasFinishedLoading {
       prependTextContent(text)
@@ -356,13 +368,29 @@ extension EditorViewController {
       return EditorSelectionHistory.selectionRange(for: fileURL, fileSize: fileSize)
     }()
 
-    bridge.core.resetEditor(text: textContent, selectionRange: selectionRange) { [weak self] _ in
-      self?.webView.magnification = 1.0
+    webView.magnification = 1.0
+    pendingResetCount += 1
+
+    Task { @MainActor [weak self] in
+      guard let self else {
+        return
+      }
+
+      _ = try? await self.bridge.core.resetEditor(
+        text: textContent,
+        selectionRange: selectionRange
+      )
+
+      self.pendingResetCount -= 1
+      if self.pendingResetCount == 0 {
+        self.resetContinuations.forEach { $0.resume() }
+        self.resetContinuations.removeAll()
+      }
 
       // Initial content from scenarios like "CreateNewDocumentIntent" or "New File from Clipboard"
-      if let text = self?.initialContent {
-        self?.prependTextContent(text)
-        self?.initialContent = nil
+      if let text = self.initialContent {
+        self.prependTextContent(text)
+        self.initialContent = nil
       }
     }
 

--- a/MarkEditMac/Sources/Editor/EditorWindowController.swift
+++ b/MarkEditMac/Sources/Editor/EditorWindowController.swift
@@ -25,6 +25,33 @@ final class EditorWindowController: NSWindowController, NSWindowDelegate {
     saveWindowRect()
   }
 
+  override func showWindow(_ sender: Any?) {
+    if shouldWaitResetting {
+      // Snapshot the caller's tabbing preference,
+      // it may be reset before our deferred super call.
+      let callerTabbingPreference = NSWindow.allowsAutomaticWindowTabbing
+
+      Task { @MainActor [weak self] in
+        guard let self else {
+          return
+        }
+
+        // Defer the actual show until the editor finishes its first paint
+        await self.editorViewController?.waitUntilEditorReset()
+
+        let tabbingToRestore = NSWindow.allowsAutomaticWindowTabbing
+        NSWindow.allowsAutomaticWindowTabbing = callerTabbingPreference
+
+        self.showWindowImmediately(sender)
+        NSWindow.allowsAutomaticWindowTabbing = tabbingToRestore
+      }
+
+      return
+    }
+
+    showWindowImmediately(sender)
+  }
+
   func windowDidBecomeMain(_ notification: Notification) {
     NSApplication.shared.closeOpenPanels()
   }
@@ -102,6 +129,18 @@ final class EditorWindowController: NSWindowController, NSWindowDelegate {
 private extension EditorWindowController {
   var editorViewController: EditorViewController? {
     contentViewController as? EditorViewController
+  }
+
+  var shouldWaitResetting: Bool {
+    guard let editor = editorViewController else {
+      return false
+    }
+
+    return editor.hasFinishedLoading && editor.pendingResetCount > 0
+  }
+
+  func showWindowImmediately(_ sender: Any?) {
+    super.showWindow(sender)
   }
 
   func updateTitleBarAppearance() {


### PR DESCRIPTION
In addition to recent performance improvements and preload changes, this change 100% removes the initial load blank due to slow creation of WebKit.