### PR TITLE
Preserve scroll on external document edits

### DIFF
--- a/CoreEditor/src/@vendor/commands/history.ts
+++ b/CoreEditor/src/@vendor/commands/history.ts
@@ -6,6 +6,8 @@ const enum BranchName { Done, Undone }
 
 const fromHistory = Annotation.define<{side: BranchName, rest: Branch, selection: EditorSelection}>()
 
+export const clearHistoryEffect = StateEffect.define<void>()
+
 /// Transaction annotation that will prevent that transaction from
 /// being combined with other transactions in the undo history. Given
 /// `"before"`, it'll prevent merging with previous transactions. With
@@ -67,6 +69,8 @@ const historyField_ = StateField.define({
       return new HistoryState(from == BranchName.Done ? fromHist.rest : other,
                               from == BranchName.Done ? other : fromHist.rest)
     }
+
+    if (tr.effects.some(effect => effect.is(clearHistoryEffect))) state = HistoryState.empty
 
     let isolate = tr.annotation(isolateHistory)
     if (isolate == "full" || isolate == "before") state = state.isolate()

--- a/CoreEditor/src/bridge/web/core.ts
+++ b/CoreEditor/src/bridge/web/core.ts
@@ -22,7 +22,11 @@ import {
  * @overrideModuleName WebBridgeCore
  */
 export interface WebModuleCore extends WebModule {
-  resetEditor({ text, selectionRange }: { text: string; selectionRange?: SelectionRange }): Promise<boolean>;
+  resetEditor({ text, selectionRange, preserveScrollPosition }: {
+    text: string;
+    selectionRange?: SelectionRange;
+    preserveScrollPosition?: boolean;
+  }): Promise<boolean>;
   getEditorState(): { hasFocus: boolean; hasSelection: boolean };
   getEditorText(): string;
   getReadableContentPair(): ReadableContentPair;
@@ -35,8 +39,12 @@ export interface WebModuleCore extends WebModule {
 }
 
 export class WebModuleCoreImpl implements WebModuleCore {
-  resetEditor({ text, selectionRange }: { text: string; selectionRange?: SelectionRange }): Promise<boolean> {
-    return resetEditor(text, selectionRange);
+  resetEditor({ text, selectionRange, preserveScrollPosition }: {
+    text: string;
+    selectionRange?: SelectionRange;
+    preserveScrollPosition?: boolean;
+  }): Promise<boolean> {
+    return resetEditor(text, selectionRange, { preserveScrollPosition });
   }
 
   getEditorState(): { hasFocus: boolean; hasSelection: boolean } {

--- a/CoreEditor/src/core.ts
+++ b/CoreEditor/src/core.ts
@@ -1,5 +1,5 @@
 import { EditorView } from '@codemirror/view';
-import { EditorSelection, EditorState } from '@codemirror/state';
+import { EditorSelection, EditorState, Text, Transaction, type ChangeSpec } from '@codemirror/state';
 import { extensions } from './extensions';
 import { globalState } from './common/store';
 import { almostEqual, afterDomUpdate, getViewportScale, isReleaseMode, isMotionReduced } from './common/utils';
@@ -19,7 +19,13 @@ import { removeFrontMatter } from './modules/frontMatter';
 import { selectedMainText, scrollIntoView, caretScrollDefaults } from './modules/selection';
 import { selectedLineColumn } from './modules/selection/selectedLineColumn';
 import { SelectionRange } from './modules/selection/types';
-import { markContentClean } from './modules/history';
+import {
+  resetContentReloadAnnotation,
+  resetCursorPlacementAnnotation,
+  resetCursorPlacementMeasureKey,
+  resetScrollRestoreMeasureKey,
+} from './modules/reset/transactionMetadata';
+import { clearHistoryEffect, markContentClean } from './modules/history';
 import { updateTextChecker } from './modules/textChecker';
 
 import { TextEditor } from './api/editor';
@@ -59,14 +65,54 @@ export enum ReplaceGranularity {
   selection = 'selection',
 }
 
+type ResetEditorOptions = {
+  /**
+   * Preserve the viewport for external reloads when no explicit selection is restored.
+   * Restored selections intentionally win over scroll preservation.
+   */
+  preserveScrollPosition?: boolean;
+};
+
+type ScrollPosition = {
+  top: number;
+  left: number;
+};
+
+type DocumentReloadChange =
+  | { kind: 'change'; changes: ChangeSpec }
+  | { kind: 'fallback' };
+
+const maxInPlaceReloadChangedCodeUnits = 20_000;
+const maxInPlaceReloadChangedDocumentRatio = 0.25;
+
 /**
  * Reset the editor to the initial state.
  */
-export async function resetEditor(initialContent: string, selectionRange?: SelectionRange): Promise<boolean> {
+export async function resetEditor(
+  initialContent: string,
+  selectionRange?: SelectionRange,
+  options: ResetEditorOptions = {},
+): Promise<boolean> {
   const lineBreak = getLineBreak(initialContent, window.config.defaultLineBreak);
   const initialDoc = normalizeLineBreaks(initialContent, lineBreak);
   const initialSelection = normalizeSelection(initialDoc.length, selectionRange);
   const selectionRestored = selectionRange !== undefined && (selectionRange.anchor !== 0 || selectionRange.head !== 0);
+  const shouldPreserveScrollPosition = options.preserveScrollPosition === true && !selectionRestored;
+  const scrollPositionToRestore = shouldPreserveScrollPosition
+    ? currentScrollPosition(window.editor)
+    : undefined;
+  const shouldScrollToTop = !selectionRestored && scrollPositionToRestore === undefined;
+  const currentEditor = window.editor;
+  const resetGeneration = ++storage.resetGeneration;
+
+  if (
+    scrollPositionToRestore !== undefined &&
+    canResetContentInPlace(currentEditor, lineBreak)
+  ) {
+    if (resetEditorContentInPlace(currentEditor, initialDoc, lineBreak, scrollPositionToRestore)) {
+      return true;
+    }
+  }
 
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   if (typeof window.editor?.destroy === 'function') {
@@ -119,7 +165,12 @@ export async function resetEditor(initialContent: string, selectionRange?: Selec
   observeContentHeightChanges(scrollDOM);
   fixWebKitWheelIssues(scrollDOM);
 
-  if (!selectionRestored) {
+  if (scrollPositionToRestore !== undefined) {
+    restoreScrollPosition(editor, scrollPositionToRestore, resetGeneration);
+    moveCursorToVisibleScrollPosition(editor, scrollPositionToRestore, resetGeneration);
+  }
+
+  if (shouldScrollToTop) {
     // Makes sure the content doesn't have unwanted inset
     scrollIntoView(0, window.config.typewriterMode ? 'center' : undefined);
     // scrollIntoView doesn't work when the app is idle
@@ -185,6 +236,13 @@ export async function resetEditor(initialContent: string, selectionRange?: Selec
     requestAnimationFrame(unblockWaiting);
     afterDomUpdate(unblockWaiting);
   });
+
+  if (scrollPositionToRestore !== undefined) {
+    scheduleMeasuredScrollRestore(editor, scrollPositionToRestore, {
+      placeCursorAfterRestore: true,
+      resetGeneration,
+    });
+  }
 
   return true;
 }
@@ -284,6 +342,221 @@ export function setHasModalSheet(value: boolean) {
   globalState.hasModalSheet = value;
 }
 
+function currentScrollPosition(editor: EditorView | null | undefined): ScrollPosition | undefined {
+  if (editor === null || editor === undefined) {
+    return undefined;
+  }
+
+  return {
+    top: editor.scrollDOM.scrollTop,
+    left: editor.scrollDOM.scrollLeft,
+  };
+}
+
+function isCurrentReset(editor: EditorView, resetGeneration: number | undefined) {
+  return window.editor === editor && (resetGeneration === undefined || storage.resetGeneration === resetGeneration);
+}
+
+function restoreScrollPosition(editor: EditorView, scrollPosition: ScrollPosition, resetGeneration?: number) {
+  if (!isCurrentReset(editor, resetGeneration)) {
+    return;
+  }
+
+  editor.scrollDOM.scrollTo({
+    top: scrollPosition.top,
+    left: scrollPosition.left,
+  });
+}
+
+function canResetContentInPlace(editor: EditorView | null | undefined, lineBreak: string | undefined): editor is EditorView {
+  if (editor === null || editor === undefined) {
+    return false;
+  }
+
+  return editor.state.lineBreak === resolvedLineBreak(lineBreak);
+}
+
+function resolvedLineBreak(lineBreak: string | undefined) {
+  return lineBreak ?? '\n';
+}
+
+function resetEditorContentInPlace(
+  editor: EditorView,
+  initialDoc: string,
+  lineBreak: string | undefined,
+  scrollPosition: ScrollPosition,
+) {
+  const reloadChange = documentReloadChanges(editor.state.doc, textFromDocumentString(initialDoc, lineBreak));
+  if (reloadChange?.kind === 'fallback') {
+    return false;
+  }
+
+  if (reloadChange !== undefined) {
+    editor.dispatch(
+      { effects: editor.scrollSnapshot() },
+      {
+        changes: reloadChange.changes,
+        effects: clearHistoryEffect.of(undefined),
+        annotations: [
+          Transaction.addToHistory.of(false),
+          Transaction.userEvent.of('@none'),
+          resetContentReloadAnnotation.of(true),
+        ],
+      },
+    );
+  } else {
+    restoreScrollPosition(editor, scrollPosition);
+  }
+
+  markContentClean();
+  return true;
+}
+
+function textFromDocumentString(doc: string, lineBreak: string | undefined) {
+  return Text.of(doc.split(lineBreak ?? /\r\n?|\n/));
+}
+
+function documentReloadChanges(currentDoc: Text, nextDoc: Text): DocumentReloadChange | undefined {
+  if (currentDoc.eq(nextDoc)) {
+    return undefined;
+  }
+
+  const currentString = currentDoc.toString();
+  const nextString = nextDoc.toString();
+  const sharedLength = Math.min(currentDoc.length, nextDoc.length);
+  let prefixLength = 0;
+  while (
+    prefixLength < sharedLength &&
+    currentString.charCodeAt(prefixLength) === nextString.charCodeAt(prefixLength)
+  ) {
+    prefixLength += 1;
+  }
+
+  let suffixLength = 0;
+  while (
+    suffixLength < sharedLength - prefixLength &&
+    currentString.charCodeAt(currentDoc.length - suffixLength - 1) ===
+      nextString.charCodeAt(nextDoc.length - suffixLength - 1)
+  ) {
+    suffixLength += 1;
+  }
+
+  const from = prefixLength;
+  const to = currentDoc.length - suffixLength;
+  const insertTo = nextDoc.length - suffixLength;
+  const changedSpanLength = Math.max(to - from, insertTo - from);
+  if (shouldFallbackForInPlaceReload(currentDoc.length, nextDoc.length, changedSpanLength)) {
+    return { kind: 'fallback' };
+  }
+
+  return {
+    kind: 'change',
+    changes: {
+      from,
+      to,
+      insert: nextDoc.slice(from, insertTo),
+    },
+  };
+}
+
+function shouldFallbackForInPlaceReload(currentLength: number, nextLength: number, changedSpanLength: number) {
+  if (changedSpanLength > maxInPlaceReloadChangedCodeUnits) {
+    return true;
+  }
+
+  const documentLength = Math.max(currentLength, nextLength);
+  return documentLength > maxInPlaceReloadChangedCodeUnits &&
+    changedSpanLength / Math.max(documentLength, 1) > maxInPlaceReloadChangedDocumentRatio;
+}
+
+function scheduleMeasuredScrollRestore(
+  editor: EditorView,
+  scrollPosition: ScrollPosition,
+  options: { placeCursorAfterRestore: boolean; resetGeneration: number },
+) {
+  if (!isCurrentReset(editor, options.resetGeneration)) {
+    return;
+  }
+
+  editor.requestMeasure({
+    key: resetScrollRestoreMeasureKey,
+    read: () => undefined,
+    write: () => {
+      restoreScrollPosition(editor, scrollPosition, options.resetGeneration);
+      if (options.placeCursorAfterRestore) {
+        schedulePostMeasuredCursorPlacement(editor, scrollPosition, options.resetGeneration);
+      }
+    },
+  });
+}
+
+function moveCursorToVisibleScrollPosition(editor: EditorView, scrollPosition: ScrollPosition, resetGeneration?: number) {
+  moveCursorToPositionAndRestoreScroll(editor, visibleCursorPosition(editor, scrollPosition), scrollPosition, resetGeneration);
+}
+
+function schedulePostMeasuredCursorPlacement(editor: EditorView, scrollPosition: ScrollPosition, resetGeneration: number) {
+  if (!isCurrentReset(editor, resetGeneration)) {
+    return;
+  }
+
+  requestAnimationFrame(() => {
+    if (!isCurrentReset(editor, resetGeneration)) {
+      return;
+    }
+
+    editor.requestMeasure({
+      key: resetCursorPlacementMeasureKey,
+      read: () => visibleCursorPosition(editor, scrollPosition),
+      write: position => {
+        if (!isCurrentReset(editor, resetGeneration)) {
+          return;
+        }
+
+        moveCursorToPositionAndRestoreScroll(editor, position, scrollPosition, resetGeneration);
+      },
+    });
+  });
+}
+
+function moveCursorToPositionAndRestoreScroll(
+  editor: EditorView,
+  position: number,
+  scrollPosition: ScrollPosition,
+  resetGeneration?: number,
+) {
+  moveCursorToPosition(editor, position, resetGeneration);
+  restoreScrollPosition(editor, scrollPosition, resetGeneration);
+  requestAnimationFrame(() => restoreScrollPosition(editor, scrollPosition, resetGeneration));
+}
+
+function moveCursorToPosition(editor: EditorView, position: number, resetGeneration?: number) {
+  if (!isCurrentReset(editor, resetGeneration)) {
+    return;
+  }
+
+  editor.dispatch({
+    selection: EditorSelection.cursor(position),
+    annotations: [
+      Transaction.addToHistory.of(false),
+      resetCursorPlacementAnnotation.of(true),
+    ],
+  });
+}
+
+function visibleCursorPosition(editor: EditorView, scrollPosition: ScrollPosition): number {
+  const rect = editor.scrollDOM.getBoundingClientRect();
+  if (rect.width > 2 && rect.height > 2) {
+    const position = editor.posAtCoords({
+      x: rect.left + Math.max(1, Math.min(rect.width / 2, rect.width - 1)),
+      y: rect.top + Math.max(1, Math.min(rect.height / 2, rect.height - 1)),
+    }, false);
+
+    return position;
+  }
+
+  return editor.lineBlockAtHeight(scrollPosition.top).from;
+}
+
 function observeContentHeightChanges(scrollDOM: HTMLElement) {
   const notifyIfChanged = () => {
     const panel = window.editor.dom.querySelector('.cm-panels-bottom');
@@ -357,11 +630,13 @@ function fixWebKitWheelIssues(scrollDOM: HTMLElement) {
 
 const storage: {
   scrollTimer: ReturnType<typeof setTimeout> | undefined;
+  resetGeneration: number;
   backgroundColor: string;
   viewportScale: number;
   bottomPanelHeight: number;
 } = {
   scrollTimer: undefined,
+  resetGeneration: 0,
   backgroundColor: '',
   viewportScale: 1.0,
   bottomPanelHeight: 0.0,

--- a/CoreEditor/src/modules/history/index.ts
+++ b/CoreEditor/src/modules/history/index.ts
@@ -1,6 +1,8 @@
 import { ViewUpdate } from '@codemirror/view';
 import { Transaction } from '@codemirror/state';
-import { undo as undoCommand, redo as redoCommand, undoDepth, redoDepth } from '../../@vendor/commands/history';
+import { undo as undoCommand, redo as redoCommand, undoDepth, redoDepth, clearHistoryEffect } from '../../@vendor/commands/history';
+
+export { clearHistoryEffect };
 
 /**
  * In the client codebase, we need to bind the native undo to this function.

--- a/CoreEditor/src/modules/input/index.ts
+++ b/CoreEditor/src/modules/input/index.ts
@@ -14,12 +14,20 @@ import { refreshEditFocus, scrollCaretToVisible, scrollToSelection, selectedLine
 
 import hasSelection from '../selection/hasSelection';
 import redrawSelectionLayer from '../selection/redrawSelectionLayer';
+import {
+  resetContentReloadAnnotation,
+  resetCursorPlacementAnnotation,
+} from '../reset/transactionMetadata';
 import wrapBlock from './wrapBlock';
 import insertCodeBlock from './insertCodeBlock';
 
 export function filterTransaction(transaction: Transaction) {
   // Return nothing for read-only mode
-  if (window.config.readOnlyMode && transaction.docChanged) {
+  if (
+    window.config.readOnlyMode &&
+    transaction.docChanged &&
+    transaction.annotation(resetContentReloadAnnotation) !== true
+  ) {
     return [];
   }
 
@@ -103,18 +111,24 @@ export function interceptInputs() {
  */
 export function observeChanges() {
   return EditorView.updateListener.of(update => {
+    const isResetContentReload = update.transactions.some(
+      tr => tr.annotation(resetContentReloadAnnotation) === true,
+    );
+
     if (update.docChanged) {
-      // This should be called before updating the native view
-      setHistoryExplictlyMoved(update);
+      if (!isResetContentReload) {
+        // This should be called before updating the native view
+        setHistoryExplictlyMoved(update);
 
-      if (!update.transactions.some(tr => tr.annotation(Transaction.userEvent) === '@none')) {
-        // We need this because we have different line height for headings,
-        // CodeMirror doesn't by default fix the offset issue.
-        scrollCaretToVisible();
+        if (!update.transactions.some(tr => tr.annotation(Transaction.userEvent) === '@none')) {
+          // We need this because we have different line height for headings,
+          // CodeMirror doesn't by default fix the offset issue.
+          scrollCaretToVisible();
 
-        // Make sure the main selection is always centered for typewriter mode
-        if (window.config.typewriterMode) {
-          scrollToSelection('center');
+          // Make sure the main selection is always centered for typewriter mode
+          if (window.config.typewriterMode) {
+            scrollToSelection('center');
+          }
         }
       }
 
@@ -129,13 +143,15 @@ export function observeChanges() {
       }
 
       // Content is updated periodically
-      if (storage.contentUpdater !== undefined) {
-        clearTimeout(storage.contentUpdater);
-      }
+      if (!isResetContentReload) {
+        if (storage.contentUpdater !== undefined) {
+          clearTimeout(storage.contentUpdater);
+        }
 
-      storage.contentUpdater = setTimeout(() => {
-        window.nativeModules.core.notifyEditorDidBecomeIdle();
-      }, 1500);
+        storage.contentUpdater = setTimeout(() => {
+          window.nativeModules.core.notifyEditorDidBecomeIdle();
+        }, 1500);
+      }
     }
 
     // CodeMirror doesn't mark `selectionSet` true when selection is cut or replaced,
@@ -163,13 +179,22 @@ export function observeChanges() {
       // debounce to skip intermediate updates. sliceDoc is deferred inside getInfo()
       // and only called when the update is actually sent. The snapshot is intentional:
       // getInfo() is consistent with the other fields captured in this update.
+      const suppressSelectionRange = update.transactions.some(
+        tr => tr.annotation(resetCursorPlacementAnnotation) === true ||
+          tr.annotation(resetContentReloadAnnotation) === true,
+      );
       const lineColumnState = selectedLineColumn();
       const notifyViewDidUpdate = () => {
+        const lineColumnInfo = lineColumnState.getInfo();
+        if (suppressSelectionRange) {
+          lineColumnInfo.selectionRange = undefined;
+        }
+
         window.nativeModules.core.notifyViewDidUpdate({
-          contentEdited: update.docChanged,
+          contentEdited: update.docChanged && !isResetContentReload,
           compositionEnded: editingState.compositionEnded,
-          isDirty: isContentDirty(),
-          selectedLineColumn: lineColumnState.getInfo(),
+          isDirty: isResetContentReload ? false : isContentDirty(),
+          selectedLineColumn: lineColumnInfo,
         });
       };
 
@@ -204,7 +229,7 @@ export function observeChanges() {
             adjustActiveLineGutter();
 
             // Content changed without key press, could be a system event like accepting inline predictions
-            if (!hasRecentKeyPress()) {
+            if (!isResetContentReload && !hasRecentKeyPress()) {
               refreshEditFocus(); // Caret can be misplaced accepting inline predictions
             }
           });

--- a/CoreEditor/src/modules/reset/transactionMetadata.ts
+++ b/CoreEditor/src/modules/reset/transactionMetadata.ts
@@ -1,0 +1,6 @@
+import { Annotation } from '@codemirror/state';
+
+export const resetContentReloadAnnotation = Annotation.define<boolean>();
+export const resetCursorPlacementAnnotation = Annotation.define<boolean>();
+export const resetScrollRestoreMeasureKey = 'MarkEdit.resetScrollRestore';
+export const resetCursorPlacementMeasureKey = 'MarkEdit.resetCursorPlacement';

--- a/CoreEditor/test/core.test.ts
+++ b/CoreEditor/test/core.test.ts
@@ -1,8 +1,14 @@
-import { describe, expect, test, beforeEach } from '@jest/globals';
+import { describe, expect, test, beforeEach, afterEach, jest } from '@jest/globals';
 import { EditorSelection } from '@codemirror/state';
+import { EditorView } from '@codemirror/view';
 import { Config } from '../src/config';
 import { performTextDrop, resetEditor } from '../src/core';
+import { canUndo } from '../src/modules/history';
 import normalizeSelection from '../src/modules/selection/normalizeSelection';
+import {
+  resetCursorPlacementMeasureKey,
+  resetScrollRestoreMeasureKey,
+} from '../src/modules/reset/transactionMetadata';
 
 // Minimal config
 window.config = {
@@ -68,6 +74,53 @@ describe('Selection clamping logic', () => {
 });
 
 describe('resetEditor selection', () => {
+  function makeScrollToObservable() {
+    return jest.spyOn(Element.prototype, 'scrollTo').mockImplementation(function (this: Element, options?: ScrollToOptions | number) {
+      if (typeof options === 'object') {
+        if (options.top !== undefined) {
+          this.scrollTop = options.top;
+        }
+
+        if (options.left !== undefined) {
+          this.scrollLeft = options.left;
+        }
+      }
+    });
+  }
+
+  type TestMeasureRequest = {
+    key?: unknown;
+    read: (view: EditorView) => unknown;
+    write?: (measure: unknown, view: EditorView) => void;
+  };
+
+  function isTestMeasureRequest(request: unknown): request is TestMeasureRequest {
+    return typeof request === 'object' &&
+      request !== null &&
+      'key' in request &&
+      typeof (request as TestMeasureRequest).read === 'function';
+  }
+
+  function mockQueuedAnimationFrames() {
+    const callbacks: FrameRequestCallback[] = [];
+
+    jest.spyOn(window, 'requestAnimationFrame').mockImplementation(callback => {
+      callbacks.push(callback);
+      return callbacks.length;
+    });
+
+    return {
+      flush() {
+        while (callbacks.length > 0) {
+          callbacks.shift()?.(0);
+        }
+      },
+      get pendingCount() {
+        return callbacks.length;
+      },
+    };
+  }
+
   beforeEach(() => {
     // Clean up previous editor
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
@@ -75,7 +128,14 @@ describe('resetEditor selection', () => {
       window.editor.destroy();
     }
 
+    window.config.readOnlyMode = false;
+    window.config.typewriterMode = false;
+    window.config.showLineNumbers = false;
     document.body.innerHTML = '';
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   test('without selection range, cursor is at 0', async () => {
@@ -125,6 +185,519 @@ describe('resetEditor selection', () => {
     const content = 'Hello, MarkEdit!';
     await resetEditor(content, { anchor: 0 as CodeGen_Int, head: 5 as CodeGen_Int });
     expect(window.editor.state.doc.toString()).toBe(content);
+  });
+
+  test('preserves scroll position when requested', async () => {
+    makeScrollToObservable();
+
+    await resetEditor(['# Heading', '', 'Body'].join('\n'));
+    window.editor.scrollDOM.scrollTop = 240;
+    window.editor.scrollDOM.scrollLeft = 12;
+
+    await resetEditor(['# Heading', '', 'Externally changed body'].join('\n'), undefined, {
+      preserveScrollPosition: true,
+    });
+
+    expect(window.editor.scrollDOM.scrollTop).toBe(240);
+    expect(window.editor.scrollDOM.scrollLeft).toBe(12);
+  });
+
+  test('updates content in place when preserving scroll and line endings match', async () => {
+    makeScrollToObservable();
+
+    await resetEditor(['# Heading', '', 'Body'].join('\n'));
+    const editor = window.editor;
+    const destroy = jest.spyOn(editor, 'destroy');
+
+    window.editor.dispatch({ selection: EditorSelection.cursor(3) });
+    window.editor.scrollDOM.scrollTop = 240;
+    window.editor.scrollDOM.scrollLeft = 12;
+    const notifyViewDidUpdate = jest.spyOn(window.nativeModules.core, 'notifyViewDidUpdate');
+    notifyViewDidUpdate.mockClear();
+
+    await resetEditor(['# Heading', '', 'Externally changed body'].join('\n'), undefined, {
+      preserveScrollPosition: true,
+    });
+
+    expect(Object.is(window.editor, editor)).toBe(true);
+    expect(destroy).not.toHaveBeenCalled();
+    expect(window.editor.state.doc.toString()).toBe(['# Heading', '', 'Externally changed body'].join('\n'));
+    expect(window.editor.state.selection.main.anchor).toBe(3);
+    expect(window.editor.scrollDOM.scrollTop).toBe(240);
+    expect(window.editor.scrollDOM.scrollLeft).toBe(12);
+    expect(canUndo()).toBe(false);
+    expect(notifyViewDidUpdate).not.toHaveBeenCalledWith(expect.objectContaining({
+      contentEdited: true,
+    }));
+    expect(notifyViewDidUpdate).toHaveBeenCalledWith(expect.objectContaining({
+      contentEdited: false,
+      isDirty: false,
+      selectedLineColumn: expect.objectContaining({
+        selectionRange: undefined,
+      }),
+    }));
+  });
+
+  test('allows in-place external reloads while read-only mode is enabled', async () => {
+    makeScrollToObservable();
+
+    await resetEditor(['# Heading', '', 'Body'].join('\n'));
+    window.config.readOnlyMode = true;
+    window.editor.scrollDOM.scrollTop = 240;
+
+    await resetEditor(['# Heading', '', 'Externally changed body'].join('\n'), undefined, {
+      preserveScrollPosition: true,
+    });
+
+    expect(window.editor.state.doc.toString()).toBe(['# Heading', '', 'Externally changed body'].join('\n'));
+    expect(window.editor.scrollDOM.scrollTop).toBe(240);
+    expect(canUndo()).toBe(false);
+  });
+
+  test('clears stale undo history after in-place external reloads', async () => {
+    makeScrollToObservable();
+
+    await resetEditor('Original content');
+    window.editor.dispatch({
+      changes: { from: 0, insert: 'User edited ' },
+    });
+    expect(canUndo()).toBe(true);
+
+    await resetEditor('Externally changed content', undefined, {
+      preserveScrollPosition: true,
+    });
+
+    expect(window.editor.state.doc.toString()).toBe('Externally changed content');
+    expect(canUndo()).toBe(false);
+  });
+
+  test('uses a mapped scroll snapshot and minimal change for in-place external reloads', async () => {
+    makeScrollToObservable();
+
+    const targetLine = '- [ ] **Step 7: Add a non-blocking measured-restore and post-restore caret regression test**';
+    const content = Array.from({ length: 300 }, (_, index) => {
+      if (index === 197) {
+        return targetLine;
+      }
+
+      return `Line ${index + 1}`;
+    }).join('\n');
+    const updatedContent = content.replace('- [ ] **Step 7', '- [x] **Step 7');
+    const checkboxOffset = content.indexOf('- [ ] **Step 7') + '- ['.length;
+
+    await resetEditor(content);
+    window.editor.scrollDOM.scrollTop = 240;
+
+    const dispatch = jest.spyOn(window.editor, 'dispatch');
+    const scrollSnapshot = jest.spyOn(window.editor, 'scrollSnapshot');
+
+    await resetEditor(updatedContent, undefined, {
+      preserveScrollPosition: true,
+    });
+
+    const reloadCall = dispatch.mock.calls.find(call => call.some(spec => (
+      typeof spec === 'object' &&
+      'changes' in spec
+    )));
+    if (reloadCall === undefined) {
+      throw new Error('Expected an in-place reload dispatch');
+    }
+
+    expect(reloadCall).toHaveLength(2);
+    expect(scrollSnapshot).toHaveBeenCalledTimes(1);
+    expect(reloadCall[0]).toEqual(expect.objectContaining({
+      effects: scrollSnapshot.mock.results[0].value,
+    }));
+    expect(reloadCall[1]).toEqual(expect.objectContaining({
+      changes: expect.objectContaining({
+        from: checkboxOffset,
+        to: checkboxOffset + 1,
+      }),
+    }));
+    expect(String((reloadCall[1] as { changes: { insert: unknown } }).changes.insert)).toBe('x');
+    expect(reloadCall[1]).not.toHaveProperty('selection');
+  });
+
+  test('uses CodeMirror coordinates for CRLF in-place external reloads', async () => {
+    makeScrollToObservable();
+
+    const lineBreak = '\r\n';
+    const targetLine = '- [ ] **Step 7: Add a non-blocking measured-restore and post-restore caret regression test**';
+    const content = Array.from({ length: 300 }, (_, index) => {
+      if (index === 197) {
+        return targetLine;
+      }
+
+      return `Line ${index + 1}`;
+    }).join(lineBreak);
+    const updatedContent = content.replace('- [ ] **Step 7', '- [x] **Step 7');
+    const checkboxOffset = content.replace(/\r\n/g, '\n').indexOf('- [ ] **Step 7') + '- ['.length;
+
+    await resetEditor(content);
+    const editor = window.editor;
+    const destroy = jest.spyOn(editor, 'destroy');
+    window.editor.scrollDOM.scrollTop = 240;
+
+    const dispatch = jest.spyOn(window.editor, 'dispatch');
+
+    await resetEditor(updatedContent, undefined, {
+      preserveScrollPosition: true,
+    });
+
+    const reloadCall = dispatch.mock.calls.find(call => call.some(spec => (
+      typeof spec === 'object' &&
+      'changes' in spec
+    )));
+    if (reloadCall === undefined) {
+      throw new Error('Expected an in-place reload dispatch');
+    }
+
+    expect(Object.is(window.editor, editor)).toBe(true);
+    expect(destroy).not.toHaveBeenCalled();
+    expect(window.editor.state.sliceDoc(0, window.editor.state.doc.length)).toBe(updatedContent);
+    expect(reloadCall[1]).toEqual(expect.objectContaining({
+      changes: expect.objectContaining({
+        from: checkboxOffset,
+        to: checkboxOffset + 1,
+      }),
+    }));
+    expect(String((reloadCall[1] as { changes: { insert: unknown } }).changes.insert)).toBe('x');
+    expect(window.editor.scrollDOM.scrollTop).toBe(240);
+  });
+
+  test('falls back to a rebuild for sparse far-apart external reload changes', async () => {
+    makeScrollToObservable();
+
+    const lines = Array.from({ length: 6000 }, (_, index) => `Line ${index + 1}`);
+    const updatedLines = [...lines];
+    updatedLines[100] = 'Changed line 101';
+    updatedLines[5000] = 'Changed line 5001';
+    const content = lines.join('\n');
+    const updatedContent = updatedLines.join('\n');
+
+    await resetEditor(content);
+    const editor = window.editor;
+    const destroy = jest.spyOn(editor, 'destroy');
+    window.editor.scrollDOM.scrollTop = 240;
+
+    await resetEditor(updatedContent, undefined, {
+      preserveScrollPosition: true,
+    });
+
+    expect(Object.is(window.editor, editor)).toBe(false);
+    expect(destroy).toHaveBeenCalled();
+    expect(window.editor.state.doc.toString()).toBe(updatedContent);
+    expect(window.editor.scrollDOM.scrollTop).toBe(240);
+  });
+
+  test('falls back when a low-ratio sparse reload span exceeds the hard in-place cap', async () => {
+    makeScrollToObservable();
+
+    const filler = '0123456789'.repeat(8);
+    const lines = Array.from({ length: 3200 }, (_, index) => `Line ${String(index + 1).padStart(4, '0')} ${filler}`);
+    const updatedLines = [...lines];
+    updatedLines[1000] = `Changed 1001 ${filler}`;
+    updatedLines[1300] = `Changed 1301 ${filler}`;
+    const content = lines.join('\n');
+    const updatedContent = updatedLines.join('\n');
+
+    await resetEditor(content);
+    const editor = window.editor;
+    const destroy = jest.spyOn(editor, 'destroy');
+    window.editor.scrollDOM.scrollTop = 240;
+
+    await resetEditor(updatedContent, undefined, {
+      preserveScrollPosition: true,
+    });
+
+    expect(Object.is(window.editor, editor)).toBe(false);
+    expect(destroy).toHaveBeenCalled();
+    expect(window.editor.state.doc.toString()).toBe(updatedContent);
+    expect(window.editor.scrollDOM.scrollTop).toBe(240);
+  });
+
+  test('reports clean state when an in-place external reload replaces dirty content', async () => {
+    makeScrollToObservable();
+
+    await resetEditor('Original content');
+    window.editor.dispatch({
+      changes: { from: 0, insert: 'User edited ' },
+    });
+    expect(canUndo()).toBe(true);
+
+    const notifyViewDidUpdate = jest.spyOn(window.nativeModules.core, 'notifyViewDidUpdate');
+    notifyViewDidUpdate.mockClear();
+
+    await resetEditor('Externally changed content', undefined, {
+      preserveScrollPosition: true,
+    });
+
+    expect(window.editor.state.doc.toString()).toBe('Externally changed content');
+    expect(canUndo()).toBe(false);
+    expect(notifyViewDidUpdate).toHaveBeenCalledWith(expect.objectContaining({
+      contentEdited: false,
+      isDirty: false,
+    }));
+  });
+
+  test('does not publish restorable selection after line-number refresh for in-place external reloads', async () => {
+    makeScrollToObservable();
+    const animationFrames = mockQueuedAnimationFrames();
+
+    window.config.showLineNumbers = true;
+
+    await resetEditor(['# Heading', '', 'Body'].join('\n'));
+    window.editor.dispatch({ selection: EditorSelection.cursor(3) });
+
+    const notifyViewDidUpdate = jest.spyOn(window.nativeModules.core, 'notifyViewDidUpdate');
+    notifyViewDidUpdate.mockClear();
+
+    await resetEditor(['# Heading', '', 'Externally changed body'].join('\n'), undefined, {
+      preserveScrollPosition: true,
+    });
+
+    notifyViewDidUpdate.mockClear();
+    animationFrames.flush();
+
+    expect(notifyViewDidUpdate).not.toHaveBeenCalledWith(expect.objectContaining({
+      selectedLineColumn: expect.objectContaining({
+        selectionRange: expect.anything(),
+      }),
+    }));
+  });
+
+  test('preserves scroll during typewriter-mode in-place external reloads', async () => {
+    makeScrollToObservable();
+
+    await resetEditor(['# Heading', '', 'Body'].join('\n'));
+    window.config.typewriterMode = true;
+    window.editor.scrollDOM.scrollTop = 240;
+
+    await resetEditor(['# Heading', '', 'Externally changed body'].join('\n'), undefined, {
+      preserveScrollPosition: true,
+    });
+
+    expect(window.editor.scrollDOM.scrollTop).toBe(240);
+  });
+
+  test('scrolls to top by default when no selection is restored', async () => {
+    makeScrollToObservable();
+
+    await resetEditor(['# Heading', '', 'Body'].join('\n'));
+    window.editor.scrollDOM.scrollTop = 240;
+
+    await resetEditor(['# Heading', '', 'New body'].join('\n'));
+
+    expect(window.editor.scrollDOM.scrollTop).toBe(0);
+  });
+
+  test('moves the cursor into the restored viewport on fallback rebuilds without publishing a restorable range', async () => {
+    makeScrollToObservable();
+
+    const content = Array.from({ length: 200 }, (_, index) => `Line ${index + 1}`).join('\n');
+    const fallbackContent = content.replace(/\n/g, '\r\n');
+    await resetEditor(content);
+    window.editor.scrollDOM.scrollTop = 240;
+
+    const notifyViewDidUpdate = jest.spyOn(window.nativeModules.core, 'notifyViewDidUpdate');
+
+    await resetEditor(fallbackContent, undefined, {
+      preserveScrollPosition: true,
+    });
+
+    const expectedAnchor = window.editor.lineBlockAtHeight(240).from;
+    expect(expectedAnchor).toBeGreaterThan(0);
+    expect(window.editor.state.selection.main.anchor).toBe(expectedAnchor);
+    expect(window.editor.state.selection.main.head).toBe(expectedAnchor);
+    expect(canUndo()).toBe(false);
+    expect(notifyViewDidUpdate).not.toHaveBeenCalledWith(expect.objectContaining({
+      selectedLineColumn: expect.objectContaining({
+        selectionRange: {
+          anchor: expectedAnchor,
+          head: expectedAnchor,
+        },
+      }),
+    }));
+  });
+
+  test('keeps restored viewport when fallback cursor placement scrolls selection into view', async () => {
+    makeScrollToObservable();
+
+    const content = Array.from({ length: 200 }, (_, index) => `Line ${index + 1}`).join('\n');
+    const fallbackContent = content.replace(/\n/g, '\r\n');
+    await resetEditor(content);
+    window.editor.scrollDOM.scrollTop = 240;
+
+    const originalDispatch = EditorView.prototype.dispatch;
+    jest.spyOn(EditorView.prototype, 'dispatch').mockImplementation(function (
+      this: EditorView,
+      ...specs: Parameters<EditorView['dispatch']>
+    ) {
+      originalDispatch.apply(this, specs);
+
+      if (specs.some(spec => typeof spec === 'object' && 'selection' in spec)) {
+        this.scrollDOM.scrollTop = 999;
+      }
+    });
+
+    await resetEditor(fallbackContent, undefined, {
+      preserveScrollPosition: true,
+    });
+
+    expect(window.editor.scrollDOM.scrollTop).toBe(240);
+  });
+
+  test('places fallback reset cursor near the viewport midpoint when layout is available', async () => {
+    makeScrollToObservable();
+
+    const content = Array.from({ length: 200 }, (_, index) => `Line ${index + 1}`).join('\n');
+    const fallbackContent = content.replace(/\n/g, '\r\n');
+    await resetEditor(content);
+    window.editor.scrollDOM.scrollTop = 240;
+
+    jest.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue({
+      x: 10,
+      y: 20,
+      width: 300,
+      height: 400,
+      top: 20,
+      right: 310,
+      bottom: 420,
+      left: 10,
+      toJSON: () => ({}),
+    });
+    const posAtCoords = jest.spyOn(EditorView.prototype, 'posAtCoords').mockReturnValue(123);
+
+    await resetEditor(fallbackContent, undefined, {
+      preserveScrollPosition: true,
+    });
+
+    expect(posAtCoords.mock.calls).toContainEqual([{
+      x: 160,
+      y: 220,
+    }, false]);
+    expect(window.editor.state.selection.main.anchor).toBe(123);
+    expect(window.editor.scrollDOM.scrollTop).toBe(240);
+  });
+
+  test('does not wait for measured restore and places cursor after delayed fallback restore', async () => {
+    makeScrollToObservable();
+    const animationFrames = mockQueuedAnimationFrames();
+
+    const content = Array.from({ length: 200 }, (_, index) => `Line ${index + 1}`).join('\n');
+    const fallbackContent = content.replace(/\n/g, '\r\n');
+    await resetEditor(content);
+    window.editor.scrollDOM.scrollTop = 240;
+
+    const requestMeasure = jest.spyOn(EditorView.prototype, 'requestMeasure').mockImplementation(() => {});
+    const measureRequests = () => requestMeasure.mock.calls
+      .map(([request]) => request)
+      .filter(isTestMeasureRequest);
+    const measureRequestsFor = (key: string) => measureRequests()
+      .filter(request => request.key === key);
+    const onlyMeasureRequestFor = (key: string) => {
+      const requests = measureRequestsFor(key);
+      expect(requests).toHaveLength(1);
+      return requests[0];
+    };
+
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    const result = await Promise.race([
+      resetEditor(fallbackContent, undefined, { preserveScrollPosition: true }).then(() => 'resolved'),
+      new Promise(resolve => {
+        timeout = setTimeout(() => resolve('timed out'), 250);
+      }),
+    ]).finally(() => {
+      if (timeout !== undefined) {
+        clearTimeout(timeout);
+      }
+    });
+
+    expect(result).toBe('resolved');
+
+    const restoreRequest = onlyMeasureRequestFor(resetScrollRestoreMeasureKey);
+    const restoreMeasure = restoreRequest.read(window.editor);
+    restoreRequest.write?.(restoreMeasure, window.editor);
+
+    expect(measureRequestsFor(resetCursorPlacementMeasureKey)).toHaveLength(0);
+    expect(animationFrames.pendingCount).toBeGreaterThan(0);
+    animationFrames.flush();
+    const cursorRequest = onlyMeasureRequestFor(resetCursorPlacementMeasureKey);
+    const cursorMeasure = cursorRequest.read(window.editor);
+    cursorRequest.write?.(cursorMeasure, window.editor);
+
+    const expectedAnchor = window.editor.lineBlockAtHeight(240).from;
+    expect(window.editor.scrollDOM.scrollTop).toBe(240);
+    expect(window.editor.state.selection.main.anchor).toBe(expectedAnchor);
+    expect(window.editor.state.selection.main.head).toBe(expectedAnchor);
+
+    const staleScrollDOM = window.editor.scrollDOM;
+    await resetEditor('Replacement editor');
+    staleScrollDOM.scrollTop = 0;
+    restoreRequest.write?.(restoreMeasure, window.editor);
+    cursorRequest.write?.(cursorMeasure, window.editor);
+    expect(staleScrollDOM.scrollTop).toBe(0);
+  });
+
+  test('ignores stale delayed fallback restores after a newer in-place reload', async () => {
+    makeScrollToObservable();
+    const animationFrames = mockQueuedAnimationFrames();
+
+    const content = Array.from({ length: 200 }, (_, index) => `Line ${index + 1}`).join('\n');
+    const fallbackContent = content.replace(/\n/g, '\r\n');
+    const updatedFallbackContent = fallbackContent.replace('Line 150', 'Changed line 150');
+    await resetEditor(content);
+    window.editor.scrollDOM.scrollTop = 240;
+
+    const requestMeasure = jest.spyOn(EditorView.prototype, 'requestMeasure').mockImplementation(() => {});
+    const measureRequests = () => requestMeasure.mock.calls
+      .map(([request]) => request)
+      .filter(isTestMeasureRequest);
+    const measureRequestsFor = (key: string) => measureRequests()
+      .filter(request => request.key === key);
+    const onlyMeasureRequestFor = (key: string) => {
+      const requests = measureRequestsFor(key);
+      expect(requests).toHaveLength(1);
+      return requests[0];
+    };
+
+    await resetEditor(fallbackContent, undefined, { preserveScrollPosition: true });
+
+    const editor = window.editor;
+    const restoreRequest = onlyMeasureRequestFor(resetScrollRestoreMeasureKey);
+    const restoreMeasure = restoreRequest.read(editor);
+    editor.scrollDOM.scrollTop = 480;
+
+    await resetEditor(updatedFallbackContent, undefined, { preserveScrollPosition: true });
+    expect(Object.is(window.editor, editor)).toBe(true);
+    expect(window.editor.scrollDOM.scrollTop).toBe(480);
+
+    const pendingFramesBeforeStaleRestore = animationFrames.pendingCount;
+    restoreRequest.write?.(restoreMeasure, editor);
+    expect(window.editor.scrollDOM.scrollTop).toBe(480);
+    expect(animationFrames.pendingCount).toBe(pendingFramesBeforeStaleRestore);
+
+    animationFrames.flush();
+
+    expect(measureRequestsFor(resetCursorPlacementMeasureKey)).toHaveLength(0);
+    expect(window.editor.scrollDOM.scrollTop).toBe(480);
+  });
+
+  test('restored selection wins over a scroll preservation request', async () => {
+    const scrollTo = makeScrollToObservable();
+
+    await resetEditor(['# Heading', '', 'Body'].join('\n'));
+    window.editor.scrollDOM.scrollTop = 240;
+
+    await resetEditor(
+      ['# Heading', '', 'Externally changed body'].join('\n'),
+      { anchor: 5 as CodeGen_Int, head: 5 as CodeGen_Int },
+      { preserveScrollPosition: true },
+    );
+
+    expect(window.editor.state.selection.main.anchor).toBe(5);
+    expect(window.editor.state.selection.main.head).toBe(5);
+    expect(scrollTo.mock.calls).not.toContainEqual([expect.objectContaining({ top: 240 })]);
   });
 });
 

--- a/MarkEditKit/Sources/Bridge/Web/Generated/WebBridgeCore.swift
+++ b/MarkEditKit/Sources/Bridge/Web/Generated/WebBridgeCore.swift
@@ -18,15 +18,17 @@ public final class WebBridgeCore {
     self.webView = webView
   }
 
-  public func resetEditor(text: String, selectionRange: SelectionRange?) async throws -> Bool {
+  public func resetEditor(text: String, selectionRange: SelectionRange?, preserveScrollPosition: Bool?) async throws -> Bool {
     struct Message: Encodable {
       let text: String
       let selectionRange: SelectionRange?
+      let preserveScrollPosition: Bool?
     }
 
     let message = Message(
       text: text,
-      selectionRange: selectionRange
+      selectionRange: selectionRange,
+      preserveScrollPosition: preserveScrollPosition
     )
 
     guard let webView else {

--- a/MarkEditKit/Sources/Bridge/Web/WebBridgeCore+Compatibility.swift
+++ b/MarkEditKit/Sources/Bridge/Web/WebBridgeCore+Compatibility.swift
@@ -1,0 +1,15 @@
+//
+//  WebBridgeCore+Compatibility.swift
+//  MarkEditKit
+//
+//  Created by cyan on 5/18/26.
+//
+
+import MarkEditCore
+
+@MainActor
+public extension WebBridgeCore {
+  func resetEditor(text: String, selectionRange: SelectionRange?) async throws -> Bool {
+    try await resetEditor(text: text, selectionRange: selectionRange, preserveScrollPosition: nil)
+  }
+}

--- a/MarkEditMac/Sources/Editor/Controllers/EditorViewController.swift
+++ b/MarkEditMac/Sources/Editor/Controllers/EditorViewController.swift
@@ -26,6 +26,7 @@ final class EditorViewController: NSViewController {
   var nativeSearchQueryChanged = false
   var bottomPanelHeight: Double = 0
   var pendingResetCount: Int = 0
+  var latestResetGeneration: Int = 0
   var initialContent: String?
   var webBackgroundColor = AppPreferences.Window.cachedBackgroundColor?.nsColor
   var localEventMonitor: Any?
@@ -351,19 +352,24 @@ extension EditorViewController {
     bridge.core.insertText(text: text, from: 0, to: 0)
   }
 
-  func resetEditor() {
+  func resetEditor(preserveScrollPosition: Bool = false) {
     guard hasFinishedLoading, let textContent = document?.stringValue else {
       return
     }
 
     let selectionRange: SelectionRange? = {
-      guard AppRuntimeConfig.restoreLastSelection, let fileURL = document?.fileURL else {
+      guard let fileURL = document?.fileURL else {
         return nil
       }
 
-      // Content was reloaded from disk due to an external edit, discard stale offsets
-      if document?.hasBeenReverted == true {
+      // Content was reloaded from disk, discard stale offsets
+      let shouldDiscardSelectionHistory = preserveScrollPosition || document?.hasBeenReverted == true
+      if shouldDiscardSelectionHistory {
         EditorSelectionHistory.discard(for: fileURL)
+        return nil
+      }
+
+      guard AppRuntimeConfig.restoreLastSelection else {
         return nil
       }
 
@@ -374,21 +380,44 @@ extension EditorViewController {
 
     webView.magnification = 1.0
     pendingResetCount += 1
+    latestResetGeneration += 1
+    let resetGeneration = latestResetGeneration
 
     Task { @MainActor [weak self] in
       guard let self else {
         return
       }
 
-      _ = try? await self.bridge.core.resetEditor(
-        text: textContent,
-        selectionRange: selectionRange
-      )
+      defer {
+        self.pendingResetCount -= 1
+        if self.pendingResetCount == 0 {
+          self.resetContinuations.forEach { $0.resume() }
+          self.resetContinuations.removeAll()
+        }
+      }
 
-      self.pendingResetCount -= 1
-      if self.pendingResetCount == 0 {
-        self.resetContinuations.forEach { $0.resume() }
-        self.resetContinuations.removeAll()
+      guard resetGeneration == self.latestResetGeneration else {
+        return
+      }
+
+      do {
+        _ = try await self.bridge.core.resetEditor(
+          text: textContent,
+          selectionRange: selectionRange,
+          preserveScrollPosition: preserveScrollPosition
+        )
+      } catch {
+        let failureMessage = "Failed to reset editor; preserveScrollPosition=\(preserveScrollPosition), " +
+          "hasSelectionRange=\(selectionRange != nil): \(error.localizedDescription)"
+        Logger.log(
+          .error,
+          failureMessage
+        )
+        return
+      }
+
+      guard resetGeneration == self.latestResetGeneration else {
+        return
       }
 
       // Initial content from scenarios like "CreateNewDocumentIntent" or "New File from Clipboard"

--- a/MarkEditMac/Sources/Editor/Models/EditorDocument.swift
+++ b/MarkEditMac/Sources/Editor/Models/EditorDocument.swift
@@ -36,6 +36,77 @@ final class EditorDocument: NSDocument {
     Date.now.timeIntervalSince(revertedDate) < 1
   }
 
+  private struct ReadIntent {
+    let generation: Int
+    let shouldPreserveScroll: Bool
+  }
+
+  private static let externalReloadReadThreadKey = "app.cyan.markedit.externalReloadReadDocument"
+
+  private var threadReadMarker: String {
+    String(describing: ObjectIdentifier(self))
+  }
+
+  private func withExternalReloadRead<T>(_ operation: () throws -> T) rethrows -> T {
+    // AppKit synchronously calls read(from:ofType:) during this revert;
+    // scope the marker to that read.
+    let threadDictionary = Thread.current.threadDictionary
+    let oldValue = threadDictionary[Self.externalReloadReadThreadKey]
+    threadDictionary[Self.externalReloadReadThreadKey] = threadReadMarker
+    defer {
+      if let oldValue {
+        threadDictionary[Self.externalReloadReadThreadKey] = oldValue
+      } else {
+        threadDictionary.removeObject(forKey: Self.externalReloadReadThreadKey)
+      }
+    }
+
+    return try operation()
+  }
+
+  private func isExternalReloadRead() -> Bool {
+    Thread.current.threadDictionary[Self.externalReloadReadThreadKey] as? String == threadReadMarker
+  }
+
+  private func nextReadIntent(shouldPreserveScroll: Bool) -> ReadIntent {
+    externalReloadReadLock.lock()
+    defer { externalReloadReadLock.unlock() }
+
+    latestReadGeneration += 1
+
+    return ReadIntent(
+      generation: latestReadGeneration,
+      shouldPreserveScroll: shouldPreserveScroll
+    )
+  }
+
+  private func applyLatestRead(
+    intent: ReadIntent,
+    data: Data,
+    stringValue: String
+  ) {
+    externalReloadReadLock.lock()
+    let latestGeneration = latestReadGeneration
+    let shouldApplyRead = intent.generation == latestGeneration
+    guard shouldApplyRead else {
+      externalReloadReadLock.unlock()
+      let staleReadMessage = "Dropping stale document read generation \(intent.generation); " +
+        "latest=\(latestGeneration), preserveScroll=\(intent.shouldPreserveScroll)"
+      Logger.log(.debug, staleReadMessage)
+      return
+    }
+
+    self.fileData = data
+    self.stringValue = stringValue
+    externalReloadReadLock.unlock()
+
+    if intent.shouldPreserveScroll {
+      hostViewController?.resetEditor(preserveScrollPosition: true)
+    } else {
+      hostViewController?.representedObject = self
+    }
+  }
+
   var canUndo: Bool {
     get async {
       if isReadOnlyMode {
@@ -78,6 +149,8 @@ final class EditorDocument: NSDocument {
   private var autosaveDelayedTask: Task<Void, Never>?
   private var textBundle: TextBundleWrapper?
   private var revertedDate: Date = .distantPast
+  private let externalReloadReadLock = NSLock()
+  private var latestReadGeneration = 0
   private var suggestedTextEncoding: EditorTextEncoding?
   private weak var hostViewController: EditorViewController?
 
@@ -339,6 +412,8 @@ extension EditorDocument {
 
 extension EditorDocument {
   override func read(from data: Data, ofType typeName: String) throws {
+    let readIntent = nextReadIntent(shouldPreserveScroll: isExternalReloadRead())
+
     DispatchQueue.global(qos: .userInitiated).async {
       let newValue = {
         if let encoding = AppDocumentController.suggestedTextEncoding {
@@ -350,9 +425,7 @@ extension EditorDocument {
       }()
 
       DispatchQueue.main.async {
-        self.fileData = data
-        self.stringValue = newValue
-        self.hostViewController?.representedObject = self
+        self.applyLatestRead(intent: readIntent, data: data, stringValue: newValue)
       }
     }
   }
@@ -409,7 +482,9 @@ extension EditorDocument {
 
         if let modificationDate, modificationDate > (self.fileModificationDate ?? .distantPast) {
           self.fileModificationDate = modificationDate
-          try self.revert(toContentsOf: fileURL, ofType: fileType)
+          try self.withExternalReloadRead {
+            try self.revert(toContentsOf: fileURL, ofType: fileType)
+          }
         }
       } catch {
         Logger.log(.error, error.localizedDescription)


### PR DESCRIPTION
## About
When using AI agents they will often checklist and update MD files while they are open side by side. Annoyingly this causes the document to scroll to the top which is unexpected.
This is especially annoying when an agent is working through a plan and checking off the list as it goes, useful to see what it's doing as it works, step by step.

This PR solves this by not scroll-jumping when external changes are made to the contents of the file.

It was also done using Codex so feel free to tell me where needs improving - I'm sure the code/fix could be better than it currently is despite the rigorous reviews by many many agents before opening the PR!

## Summary
- Preserve scroll position when a document reloads after an external file change, using safe in-place CodeMirror updates when possible.
- Fall back to a measured rebuild restore path for line-ending changes and oversized sparse reload spans.
- Thread the preserve-scroll option through the web/Swift bridge and native external reload path, with stale reset/read guards and regression coverage.

## Test Plan
- `npm exec --yes corepack@latest -- yarn test --runInBand`
- `npm exec --yes corepack@latest -- yarn build`
- `xcodebuild test -project MarkEdit.xcodeproj -scheme MarkEditCoreTests -destination 'platform=macOS' -derivedDataPath /tmp/markedit-external-scroll-derived-data CODE_SIGN_IDENTITY='' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO`\n- `xcodebuild test -project MarkEdit.xcodeproj -scheme ModulesTests -destination 'platform=macOS' -derivedDataPath /tmp/markedit-external-scroll-derived-data CODE_SIGN_IDENTITY='' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO`\n- `xcodebuild build -project MarkEdit.xcodeproj -scheme MarkEditMac -destination 'platform=macOS' -derivedDataPath /tmp/markedit-external-scroll-derived-data CODE_SIGN_IDENTITY='' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO`
- Manual validation: mid-document, top, and end-of-document external edits, with and without typewriter mode.