### PR TITLE
Reuse current window's tab group when opening files

### DIFF
--- a/MarkEditMac/Sources/Main/AppDocumentController.swift
+++ b/MarkEditMac/Sources/Main/AppDocumentController.swift
@@ -69,11 +69,46 @@ final class AppDocumentController: NSDocumentController {
       // Ensure the preloader has a fully loaded editor before opening the document
       await EditorPreloader.shared.prepareViewController()
 
+      // Pick a target tab-group host: if a usable editor window is up front,
+      // we want the newly opened document to join that window's tab group
+      // instead of becoming a standalone window. nil means "open standalone".
+      let targetWindow = Self.tabTargetWindow(for: url)
+
+      guard let targetWindow else {
+        super.openDocument(
+          withContentsOf: url,
+          display: displayDocument,
+          completionHandler: completionHandler
+        )
+        return
+      }
+
+      // Same pattern as reopenClosedTab: temporarily disable auto-tabbing so
+      // the new window opens standalone, then we manually attach it to the
+      // target's tab group. EditorWindowController.showWindow snapshots this
+      // value synchronously, so it must be set before super.openDocument.
+      Self.suppressAutomaticTabbing()
       super.openDocument(
         withContentsOf: url,
-        display: displayDocument,
-        completionHandler: completionHandler
-      )
+        display: displayDocument
+      ) { document, alreadyOpen, error in
+        Self.restoreAutomaticTabbing()
+
+        if !alreadyOpen, error == nil,
+           let editorDocument = document as? EditorDocument {
+          Task { @MainActor in
+            guard let newWindow = editorDocument.windowControllers.first?.window,
+                  newWindow !== targetWindow,
+                  newWindow.tabGroup !== targetWindow.tabGroup else {
+              return
+            }
+
+            targetWindow.addTabbedWindow(newWindow, ordered: .above)
+          }
+        }
+
+        completionHandler(document, alreadyOpen, error)
+      }
     }
   }
 
@@ -83,7 +118,65 @@ final class AppDocumentController: NSDocumentController {
   }
 }
 
+// MARK: - Automatic tabbing suppression
+
+extension AppDocumentController {
+  private enum AutoTabbingStates {
+    @MainActor static var inFlightCount = 0
+    @MainActor static var savedValue: Bool?
+  }
+
+  /// Temporarily forces `NSWindow.allowsAutomaticWindowTabbing` to `false`.
+  ///
+  /// Reference-counted so overlapping callers (e.g. rapid Cmd+Shift+T, or a
+  /// batch of files opened together) don't clobber each other's saved state.
+  /// Pair every call with `restoreAutomaticTabbing()`.
+  @MainActor
+  static func suppressAutomaticTabbing() {
+    if AutoTabbingStates.inFlightCount == 0 {
+      AutoTabbingStates.savedValue = NSWindow.allowsAutomaticWindowTabbing
+      NSWindow.allowsAutomaticWindowTabbing = false
+    }
+
+    AutoTabbingStates.inFlightCount += 1
+  }
+
+  @MainActor
+  static func restoreAutomaticTabbing() {
+    AutoTabbingStates.inFlightCount -= 1
+    if AutoTabbingStates.inFlightCount == 0 {
+      NSWindow.allowsAutomaticWindowTabbing = AutoTabbingStates.savedValue ?? true
+      AutoTabbingStates.savedValue = nil
+    }
+  }
+}
+
 // MARK: - Private
+
+private extension AppDocumentController {
+  @MainActor
+  static func tabTargetWindow(for url: URL) -> EditorWindow? {
+    if AppPreferences.Window.tabbingMode == .disallowed {
+      return nil
+    }
+
+    // If the document is already open, NSDocumentController will reuse it and
+    // raise its existing window/tab — we must not inject a new tab attachment.
+    let alreadyOpen = NSDocumentController.shared.documents.contains { document in
+      guard let existing = document.fileURL else {
+        return false
+      }
+
+      return existing == url || existing.resolvingSymlinksInPath() == url.resolvingSymlinksInPath()
+    }
+
+    if alreadyOpen {
+      return nil
+    }
+
+    return (NSApp.keyWindow as? EditorWindow) ?? (NSApp.mainWindow as? EditorWindow)
+  }
+}
 
 private extension NSOpenPanel {
   /// Re-layouts the accessory view to work around internal AppKit bugs.

--- a/MarkEditMac/Sources/Main/Application/AppDelegate+ClosedTab.swift
+++ b/MarkEditMac/Sources/Main/Application/AppDelegate+ClosedTab.swift
@@ -11,11 +11,6 @@ import MarkEditKit
 // MARK: - Closed Tab
 
 extension AppDelegate {
-  private enum ReopenStates {
-    @MainActor static var inFlightCount = 0
-    @MainActor static var savedAllowsAutomaticWindowTabbing: Bool?
-  }
-
   @IBAction func reopenClosedTab(_ sender: Any?) {
     guard let entry = EditorClosedTabHistory.shared.pop() else {
       NSSound.beep()
@@ -45,22 +40,13 @@ extension AppDelegate {
 
     // openDocument(display:true) normally auto-joins the key window's tab group.
     // Temporarily disable this so the window opens standalone, then we manually
-    // addTabbedWindow to the correct target. Counter handles rapid Cmd+Shift+T.
-    if ReopenStates.inFlightCount == 0 {
-      ReopenStates.savedAllowsAutomaticWindowTabbing = NSWindow.allowsAutomaticWindowTabbing
-      NSWindow.allowsAutomaticWindowTabbing = false
-    }
-
-    ReopenStates.inFlightCount += 1
+    // addTabbedWindow to the correct target.
+    AppDocumentController.suppressAutomaticTabbing()
     NSDocumentController.shared.openDocument(
       withContentsOf: entry.url,
       display: true
     ) { document, _, error in
-      ReopenStates.inFlightCount -= 1
-      if ReopenStates.inFlightCount == 0 {
-        NSWindow.allowsAutomaticWindowTabbing = ReopenStates.savedAllowsAutomaticWindowTabbing ?? true
-        ReopenStates.savedAllowsAutomaticWindowTabbing = nil
-      }
+      AppDocumentController.restoreAutomaticTabbing()
 
       if let error {
         NSSound.beep()


### PR DESCRIPTION
## Summary

Opening a file from Finder (double-click, drag-to-Dock) currently spawns a new standalone window even when another editor window is already up front. This change attaches the new window to the front window's tab group instead, matching the behavior users already get from `reopenClosedTab` (Cmd+Shift+T).

- New files: when `Window > Tabbing Mode` is not `.disallowed` and an `EditorWindow` is key/main, attach the newly opened window to that window via `addTabbedWindow(_:ordered:)`.
- Already-open files: rely on `NSDocumentController`'s built-in dedup — `super.openDocument(...)` reuses the existing document and raises its tab, no manual injection needed.
- `.disallowed` opt-out and the "no existing window" case both fall through to the original behavior (standalone window).
- The auto-tabbing suppression dance (`NSWindow.allowsAutomaticWindowTabbing = false`, then manual attach) used to live as a private reference counter inside `AppDelegate+ClosedTab.swift`. Extracted it to `AppDocumentController.suppressAutomaticTabbing()` / `restoreAutomaticTabbing()` so both code paths share the same counter and don't fight each other when, e.g., a batch open overlaps with Cmd+Shift+T.

State restoration on launch is unaffected — it doesn't flow through `openDocument(withContentsOf:)`.

## Test plan

- [ ] One editor window in front, double-click another `.md` in Finder → opens as a new tab in the same window.
- [ ] One editor window in front, double-click a file already open in it → window comes forward and the existing tab is selected; no new tab.
- [ ] `Window > Tabbing Mode = Disallowed`, double-click from Finder → still opens as a standalone window.
- [ ] Quit all editor windows, double-click from Finder → opens a new standalone window.
- [ ] Drop 3 files onto the Dock icon at once → all three land as tabs of the same window.
- [ ] Close a tab and Cmd+Shift+T → unchanged: tab returns to its original group at its original index.