### PR TITLE
Add native PDF export module with WKWebView createPDF support

### DIFF
--- a/CoreEditor/index.ts
+++ b/CoreEditor/index.ts
@@ -23,6 +23,7 @@ import { NativeModuleTokenizer } from './src/bridge/native/tokenizer';
 import { NativeModuleAPI } from './src/bridge/native/api';
 import { NativeModuleFoundationModels } from './src/bridge/native/foundationModels';
 import { NativeModuleTranslation } from './src/bridge/native/translation';
+import { NativeModulePDF } from './src/bridge/native/pdf';
 
 import { resetEditor } from './src/core';
 import { initThemeExtractors, initMarkEditModules } from './src/api/modules';
@@ -82,6 +83,7 @@ window.nativeModules = {
   api: createNativeModule<NativeModuleAPI>('api'),
   foundationModels: createNativeModule<NativeModuleFoundationModels>('foundationModels'),
   translation: createNativeModule<NativeModuleTranslation>('translation'),
+  pdf: createNativeModule<NativeModulePDF>('pdf'),
 };
 
 // In release mode, override window APIs to bridge to native

--- a/CoreEditor/src/@types/global.d.ts
+++ b/CoreEditor/src/@types/global.d.ts
@@ -7,6 +7,7 @@ import { NativeModuleTokenizer } from '../bridge/native/tokenizer';
 import { NativeModuleAPI } from '../bridge/native/api';
 import { NativeModuleFoundationModels } from '../bridge/native/foundationModels';
 import { NativeModuleTranslation } from '../bridge/native/translation';
+import { NativeModulePDF } from '../bridge/native/pdf';
 
 import type { EditorView } from '@codemirror/view';
 import type { Extension } from '@codemirror/state';
@@ -49,6 +50,7 @@ declare global {
       api: NativeModuleAPI;
       foundationModels: NativeModuleFoundationModels;
       translation: NativeModuleTranslation;
+      pdf: NativeModulePDF;
     };
     __extractStyleRules__: (theme: Extension) => string[] | undefined;
     __extractHighlightSpecs__: (theme: Extension) => TagStyle[] | undefined;
@@ -60,6 +62,12 @@ declare global {
 
   interface ImportMeta {
     readonly env: ImportMetaEnv;
+  }
+}
+
+declare module 'markedit-api' {
+  interface MarkEdit {
+    generatePDF(html: string, fileName?: string): Promise<boolean>;
   }
 }
 

--- a/CoreEditor/src/api/modules.ts
+++ b/CoreEditor/src/api/modules.ts
@@ -21,6 +21,7 @@ import { onAppReady, onEditorReady, saveDocument, closeDocument, addExtension, a
 import { addMainMenuItem, showContextMenu, showAlert, showTextBox, showSavePanel, runService } from './ui';
 import { openFile, createFile, deleteFile, moveFile, revealFile, listFiles, getFileContent, getFileObject, getFileInfo, getDirectoryPath } from './files';
 import { getPasteboardItems, getPasteboardString } from './pasteboard';
+import { generatePDF } from './pdf';
 
 export function initMarkEditModules() {
   const codemirror = {
@@ -77,6 +78,7 @@ export function initMarkEditModules() {
   MarkEdit.getDirectoryPath = getDirectoryPath;
   MarkEdit.getPasteboardItems = getPasteboardItems;
   MarkEdit.getPasteboardString = getPasteboardString;
+  Object.assign(MarkEdit, { generatePDF });
 
   // Override the share method to provide a clear error message
   navigator.share = (_: ShareData): Promise<void> => {

--- a/CoreEditor/src/api/pdf.ts
+++ b/CoreEditor/src/api/pdf.ts
@@ -1,0 +1,3 @@
+export async function generatePDF(html: string, fileName?: string): Promise<boolean> {
+  return window.nativeModules.pdf.generate({ html, fileName });
+}

--- a/CoreEditor/src/bridge/native/pdf.ts
+++ b/CoreEditor/src/bridge/native/pdf.ts
@@ -1,0 +1,10 @@
+import { NativeModule } from '../nativeModule';
+
+/**
+ * @shouldExport true
+ * @invokePath pdf
+ * @bridgeName NativeBridgePDF
+ */
+export interface NativeModulePDF extends NativeModule {
+  generate({ html, fileName }: { html: string; fileName?: string }): Promise<boolean>;
+}

--- a/MarkEditKit/Sources/Bridge/Native/Generated/NativeModulePDF.swift
+++ b/MarkEditKit/Sources/Bridge/Native/Generated/NativeModulePDF.swift
@@ -1,0 +1,55 @@
+//
+//  NativeModulePDF.swift
+//
+//  Generated using https://github.com/microsoft/ts-gyb
+//
+//  Don't modify this file manually, it's auto generated.
+//
+//  To make changes, edit template files under /CoreEditor/src/@codegen
+
+import Foundation
+import MarkEditCore
+
+@MainActor
+public protocol NativeModulePDF: NativeModule {
+  func generate(html: String, fileName: String?) async -> Bool
+}
+
+public extension NativeModulePDF {
+  var bridge: NativeBridge { NativeBridgePDF(self) }
+}
+
+@MainActor
+final class NativeBridgePDF: NativeBridge {
+  static let name = "pdf"
+  lazy var methods: [String: NativeMethod] = [
+    "generate": { [weak self] in
+      await self?.generate(parameters: $0)
+    },
+  ]
+
+  private let module: NativeModulePDF
+  private lazy var decoder = JSONDecoder()
+
+  init(_ module: NativeModulePDF) {
+    self.module = module
+  }
+
+  private func generate(parameters: Data) async -> Result<Any?, Error>? {
+    struct Message: Decodable {
+      var html: String
+      var fileName: String?
+    }
+
+    let message: Message
+    do {
+      message = try decoder.decode(Message.self, from: parameters)
+    } catch {
+      Logger.assertFail("Failed to decode parameters: \(parameters)")
+      return .failure(error)
+    }
+
+    let result = await module.generate(html: message.html, fileName: message.fileName)
+    return .success(result)
+  }
+}

--- a/MarkEditKit/Sources/Bridge/Native/Modules/EditorModulePDF.swift
+++ b/MarkEditKit/Sources/Bridge/Native/Modules/EditorModulePDF.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+@MainActor
+public protocol EditorModulePDFDelegate: AnyObject {
+  func editorPDF(_ sender: EditorModulePDF, generate html: String, fileName: String?) async -> Bool
+}
+
+public final class EditorModulePDF: NativeModulePDF {
+  private weak var delegate: EditorModulePDFDelegate?
+
+  public init(delegate: EditorModulePDFDelegate) {
+    self.delegate = delegate
+  }
+
+  public func generate(html: String, fileName: String?) async -> Bool {
+    await delegate?.editorPDF(self, generate: html, fileName: fileName) == true
+  }
+}

--- a/MarkEditMac/Sources/Editor/Controllers/EditorViewController+Delegate.swift
+++ b/MarkEditMac/Sources/Editor/Controllers/EditorViewController+Delegate.swift
@@ -489,6 +489,69 @@ extension EditorViewController: EditorReplacePanelDelegate {
   }
 }
 
+// MARK: - EditorModulePDFDelegate
+
+extension EditorViewController: EditorModulePDFDelegate {
+  func editorPDF(_ sender: EditorModulePDF, generate html: String, fileName: String?) async -> Bool {
+    guard let data = await renderPDF(from: html) else {
+      return false
+    }
+
+    return await showSavePanel(data: data, fileName: fileName ?? "Untitled.pdf")
+  }
+}
+
+// MARK: - Private
+
+private extension EditorViewController {
+  func renderPDF(from html: String) async -> Data? {
+    let pdfWaiter = PDFLoadWaiter()
+    let webView = WKWebView(frame: CGRect(x: 0, y: 0, width: 800, height: 1000))
+    webView.navigationDelegate = pdfWaiter
+    webView.loadHTMLString(html, baseURL: nil)
+
+    await pdfWaiter.waitForLoad()
+
+    return await withCheckedContinuation { continuation in
+      webView.createPDF(configuration: WKPDFConfiguration()) { result in
+        switch result {
+        case .success(let data):
+          continuation.resume(returning: data)
+        case .failure:
+          continuation.resume(returning: nil)
+        }
+      }
+    }
+  }
+}
+
+// MARK: - PDFLoadWaiter
+
+@MainActor
+private final class PDFLoadWaiter: NSObject, WKNavigationDelegate {
+  private var continuation: CheckedContinuation<Void, Never>?
+  private var didFinish = false
+
+  func waitForLoad() async {
+    if didFinish { return }
+    await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+      self.continuation = continuation
+    }
+  }
+
+  func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) { // swiftlint:disable:this implicitly_unwrapped_optional
+    didFinish = true
+    continuation?.resume()
+    continuation = nil
+  }
+
+  func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) { // swiftlint:disable:this implicitly_unwrapped_optional
+    didFinish = true
+    continuation?.resume()
+    continuation = nil
+  }
+}
+
 // MARK: - App ready
 
 private extension EditorViewController {

--- a/MarkEditMac/Sources/Editor/Controllers/EditorViewController.swift
+++ b/MarkEditMac/Sources/Editor/Controllers/EditorViewController.swift
@@ -133,6 +133,7 @@ final class EditorViewController: NSViewController {
       EditorModulePreview(delegate: self),
       EditorModuleTokenizer(),
       EditorModuleAPI(delegate: self),
+      EditorModulePDF(delegate: self),
       EditorModuleFoundationModels(delegate: self),
       EditorModuleTranslation(),
     ])


### PR DESCRIPTION
<!--

Thanks for taking the time to contribute! Before opening this PR, please read the notes below — MarkEdit is a small project with a narrow scope, and not every PR can be accepted. Setting expectations early saves everyone time.

For non-trivial changes, always open an issue to discuss with maintainers first. PRs without a prior issue discussion (especially ones that change behavior, UI, or defaults) will likely be closed without review.

You can skip this step for trivial bug fixes or performance improvements.

-->

I added support for PDF export via small changes in the main app and your preview extension. It may help others even if it doesn't fit the project scope.  

## Checklist

- [x] I have followed the [development guide](https://github.com/MarkEdit-app/MarkEdit/wiki/Development) and matched the existing code style
- [x] I have performed a self-review of my own code, kept the diff minimal, and avoided unrelated changes
- [ x I have smoke tested the change, covering the main affected paths
- [x] For user-visible strings: localization keys have been added/updated as needed
- [ ] For UI changes: I have attached before/after screenshots or a short screen recording
