### PR TITLE
Fix appearance override across app restarts

### DIFF
--- a/MarkEditMac/Sources/Main/Application/AppDelegate.swift
+++ b/MarkEditMac/Sources/Main/Application/AppDelegate.swift
@@ -56,11 +56,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
   private var settingsWindowController: NSWindowController?
 
   func applicationWillFinishLaunching(_ notification: Notification) {
+    NSApp.appearance = AppPreferences.General.appearance.resolved()
     EditorPreloader.shared.warmUp()
   }
 
   func applicationDidFinishLaunching(_ notification: Notification) {
-    NSApp.appearance = AppPreferences.General.appearance.resolved()
     appearanceObservation = NSApp.observe(\.effectiveAppearance) { _, _ in
       Task { @MainActor in
         AppTheme.current.updateAppearance()


### PR DESCRIPTION
This is a potential fix for issue #1491 where manually setting the dark/light mode appearance does not 'stick' across app restarts.

Claude Code analyzed the problem and created the fix here to move `NSApp.appearance` setup to `applicationWillFinishLaunching`, **before** `warmUp()` and before macOS can restore any windows:

## Checklist

- [x] I have followed the [development guide](https://github.com/MarkEdit-app/MarkEdit/wiki/Development) and matched the existing code style
- [x] I have performed a self-review of my own code, kept the diff minimal, and avoided unrelated changes
- [x] I have smoke tested the change, covering the main affected paths
- [ ] For user-visible strings: localization keys have been added/updated as needed
- [ ] For UI changes: I have attached before/after screenshots or a short screen recording

I created a local build with my change and have tested on two different Mac laptops and it seems to fix the issue.