### PR TITLE
[macOS 27] Bring back Writing Tools

### DIFF
--- a/MarkEditMac/Base.lproj/Main.storyboard
+++ b/MarkEditMac/Base.lproj/Main.storyboard
@@ -610,6 +610,16 @@ Gw
                                                 </items>
                                             </menu>
                                         </menuItem>
+                                        <menuItem title="Writing Tools (Placeholder)" hidden="YES" id="BWI-Qs-d6i">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Writing Tools (Placeholder)" id="gSc-Jf-IPB">
+                                                <items>
+                                                    <menuItem id="Mnm-0W-s1w">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
                                         <menuItem title="Spelling and Grammar" id="Dv1-io-Yv7">
                                             <modifierMask key="keyEquivalentModifierMask"/>
                                             <menu key="submenu" title="Spelling" id="3IN-sU-3Bg">
@@ -1054,6 +1064,7 @@ Gw
                         <outlet property="editTableOfContentsMenu" destination="BxI-nv-Xa5" id="lTp-Xn-8tg"/>
                         <outlet property="editTypewriterItem" destination="Cvo-jv-iDg" id="1vS-bx-fNh"/>
                         <outlet property="editUndoItem" destination="dRJ-4n-Yzg" id="Qet-C4-yT2"/>
+                        <outlet property="editWritingToolsItem" destination="BWI-Qs-d6i" id="yvo-s9-n7K"/>
                         <outlet property="fileFromClipboardItem" destination="0NS-5A-glR" id="hxk-Eb-8YJ"/>
                         <outlet property="formatBulletItem" destination="ANX-uP-CA4" id="4cQ-3z-hPG"/>
                         <outlet property="formatCodeBlockItem" destination="QOM-rI-Bxj" id="4Dy-YC-z6y"/>

--- a/MarkEditMac/Modules/Sources/AppKitExtensions/UI/NSMenuItem+Extension.swift
+++ b/MarkEditMac/Modules/Sources/AppKitExtensions/UI/NSMenuItem+Extension.swift
@@ -7,6 +7,15 @@
 import AppKit
 
 public extension NSMenuItem {
+  static var systemWritingToolsItem: Self? {
+    let selector = sel_getUid("standardWritingToolsMenuItem")
+    guard responds(to: selector) else {
+      return nil
+    }
+
+    return perform(selector)?.takeUnretainedValue() as? Self
+  }
+
   convenience init(title: String) {
     self.init(title: title, action: nil, keyEquivalent: "")
   }

--- a/MarkEditMac/Modules/Tests/RuntimeTests.swift
+++ b/MarkEditMac/Modules/Tests/RuntimeTests.swift
@@ -173,6 +173,16 @@ final class RuntimeTests: XCTestCase {
     let object = type?.value(forKey: "defaultManager") as? AnyObject
     XCTAssertEqual(object?.responds(to: sel_getUid("loadAXBundles")), true, "Missing loadAXBundles")
   }
+
+  func testExistenceOfShowWritingTools() {
+    let webView = WKWebView()
+    testExistenceOfSelector(object: webView, selector: "_showWritingTools")
+  }
+
+  func testExistenceOfStandardWritingToolsMenuItem() {
+    let item = NSMenuItem.systemWritingToolsItem
+    XCTAssertNotNil(item)
+  }
 }
 
 // MARK: - Private

--- a/MarkEditMac/Resources/Localizable.xcstrings
+++ b/MarkEditMac/Resources/Localizable.xcstrings
@@ -2638,6 +2638,23 @@
         }
       }
     },
+    "Show Writing Tools" : {
+      "comment" : "Show Writing Tools",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示写作工具"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示書寫工具"
+          }
+        }
+      }
+    },
     "Show:" : {
       "comment" : "Label for display options",
       "localizations" : {

--- a/MarkEditMac/Sources/Editor/Controllers/EditorViewController+Menu.swift
+++ b/MarkEditMac/Sources/Editor/Controllers/EditorViewController+Menu.swift
@@ -44,13 +44,6 @@ extension EditorViewController {
     item.submenu = menu
     return item
   }
-
-  @available(macOS 15.1, *)
-  var systemWritingToolsMenu: NSMenu? {
-    NSApp.appDelegate?.mainEditMenu?.items.first {
-      $0.identifier?.rawValue == "__NSTextViewContextSubmenuIdentifierWritingTools"
-    }?.submenu
-  }
 }
 
 // MARK: - NSMenuDelegate

--- a/MarkEditMac/Sources/Editor/Controllers/EditorViewController+Toolbar.swift
+++ b/MarkEditMac/Sources/Editor/Controllers/EditorViewController+Toolbar.swift
@@ -262,11 +262,16 @@ private extension EditorViewController {
   }
 
   var writingToolsItem: NSToolbarItem? {
-    if #available(macOS 15.1, *), let menu = systemWritingToolsMenu {
+    if #available(macOS 15.1, *), let menu = NSApp.appDelegate?.activeWritingToolsItem?.submenu {
       return .with(identifier: .writingTools, menu: menu.copiedMenu)
-    } else {
-      return nil
     }
+
+    // [macOS 27] Always enable "Writing Tools"
+    if AppDesign.forceWritingTools, let menu = NSMenuItem.systemWritingToolsItem?.submenu {
+      return .with(identifier: .writingTools, menu: menu.copiedMenu)
+    }
+
+    return nil
   }
 
   func updateTableOfContentsMenu(_ menu: NSMenu) {

--- a/MarkEditMac/Sources/Editor/Views/EditorWebView.swift
+++ b/MarkEditMac/Sources/Editor/Views/EditorWebView.swift
@@ -108,6 +108,11 @@ final class EditorWebView: WKWebView {
       return true
     }
 
+    // Always enable "Show Writing Tools"
+    if #available(macOS 27.0, *), AppDesign.forceWritingTools {
+      AppWritingTools.ensureWritingTools(menu: menu)
+    }
+
     // Actions like select all in selection, replace all in selection, etc
     if let searchMenuItem = actionDelegate?.editorWebViewSearchActionsMenuItem(self) {
       menu.insertItem(searchMenuItem, at: 0)

--- a/MarkEditMac/Sources/Main/AppDesign.swift
+++ b/MarkEditMac/Sources/Main/AppDesign.swift
@@ -6,6 +6,7 @@
 //
 
 import AppKit
+import FoundationModels
 
 @MainActor
 enum AppDesign {
@@ -36,6 +37,21 @@ enum AppDesign {
    */
   static var menuIconEvolution: Bool {
     modernStyle
+  }
+
+  /**
+   Returns `true` to always enable `Show Writing Tools` in macOS Golden Gate.
+
+   [macOS 27] Apple Bug: `Ask Siri` and `Show Writing Tools` are both missing.
+   */
+  static var forceWritingTools: Bool {
+    guard #available(macOS 27.0, *) else {
+      return false
+    }
+
+    // Don't use NSWritingToolsCoordinator.isWritingToolsAvailable here,
+    // it returns `false` when "New Siri" is enabled.
+    return SystemLanguageModel.default.isAvailable
   }
 
   static var dividerAlpha: Double {

--- a/MarkEditMac/Sources/Main/AppResources.swift
+++ b/MarkEditMac/Sources/Main/AppResources.swift
@@ -110,6 +110,7 @@ enum Localized {
 
   enum WritingTools {
     static let featureName = String(localized: "Writing Tools", comment: "Writing Tools")
+    static let menuItemTitle = String(localized: "Show Writing Tools", comment: "Show Writing Tools")
   }
 
   enum Settings {

--- a/MarkEditMac/Sources/Main/AppWritingTools.swift
+++ b/MarkEditMac/Sources/Main/AppWritingTools.swift
@@ -86,6 +86,33 @@ enum AppWritingTools {
     // These tools can start without text selections
     tool != .smartReply && tool != .compose
   }
+
+  @available(macOS 27.0, *)
+  static func ensureWritingTools(menu: NSMenu) {
+    guard !(menu.items.contains { $0.identifier == .writingTools }) else {
+      return
+    }
+
+    let item = NSMenuItem(
+      title: Localized.WritingTools.menuItemTitle,
+      action: sel_getUid("_showWritingTools"),
+      keyEquivalent: ""
+    )
+
+    let index: Int = {
+      // Before "Spelling and Grammar"
+      if let target = (menu.items.first { $0.identifier == .spellingMenu }) {
+        return menu.index(of: target)
+      }
+
+      // Or as the first one
+      return 0
+    }()
+
+    item.identifier = .writingTools
+    menu.items.insert(item, at: index)
+    menu.items.insert(.separator(), at: index + 1)
+  }
 }
 
 // MARK: - Private
@@ -121,4 +148,9 @@ private extension AppWritingTools {
 
     return (selector, target.method(for: selector))
   }
+}
+
+private extension NSUserInterfaceItemIdentifier {
+  static let writingTools = Self("WKMenuItemIdentifierWritingTools")
+  static let spellingMenu = Self("WKMenuItemIdentifierSpellingMenu")
 }

--- a/MarkEditMac/Sources/Main/Application/AppDelegate+Menu.swift
+++ b/MarkEditMac/Sources/Main/Application/AppDelegate+Menu.swift
@@ -9,6 +9,13 @@ import AppKit
 import MarkEditKit
 
 extension AppDelegate: NSMenuDelegate {
+  @available(macOS 15.1, *)
+  var activeWritingToolsItem: NSMenuItem? {
+    mainEditMenu?.items.first {
+      $0.identifier?.rawValue == "__NSTextViewContextSubmenuIdentifierWritingTools"
+    }
+  }
+
   func menuNeedsUpdate(_ menu: NSMenu) {
     switch menu {
     case mainFileMenu:
@@ -51,6 +58,18 @@ private extension AppDelegate {
       editUndoItem?.isEnabled = await document.canUndo
       editRedoItem?.isEnabled = await document.canRedo
       editPasteItem?.isEnabled = NSPasteboard.general.hasText
+    }
+
+    // [macOS 27] Always enable "Writing Tools"
+    if #available(macOS 27.0, *), AppDesign.forceWritingTools {
+      // Prevent duplicate items
+      editWritingToolsItem?.isHidden = !(activeWritingToolsItem?.isHidden ?? true)
+
+      // Copy properties from `standardWritingToolsMenuItem`
+      let systemItem = NSMenuItem.systemWritingToolsItem
+      editWritingToolsItem?.submenu = systemItem?.submenu?.copiedMenu
+      editWritingToolsItem?.title = systemItem?.title ?? Localized.WritingTools.featureName
+      editWritingToolsItem?.image = AppWritingTools.affordanceIcon
     }
 
     editTypewriterItem?.setOn(AppPreferences.Editor.typewriterMode)

--- a/MarkEditMac/Sources/Main/Application/AppDelegate.swift
+++ b/MarkEditMac/Sources/Main/Application/AppDelegate.swift
@@ -35,6 +35,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
   @IBOutlet weak var editRedoItem: NSMenuItem?
   @IBOutlet weak var editPasteItem: NSMenuItem?
   @IBOutlet weak var editGotoLineItem: NSMenuItem?
+  @IBOutlet weak var editWritingToolsItem: NSMenuItem?
   @IBOutlet weak var editReadOnlyItem: NSMenuItem?
   @IBOutlet weak var editStatisticsItem: NSMenuItem?
   @IBOutlet weak var editTypewriterItem: NSMenuItem?

--- a/MarkEditMac/mul.lproj/Main.xcstrings
+++ b/MarkEditMac/mul.lproj/Main.xcstrings
@@ -1022,6 +1022,19 @@
         }
       }
     },
+    "BWI-Qs-d6i.title" : {
+      "comment" : "Class = \"NSMenuItem\"; title = \"Writing Tools (Placeholder)\"; ObjectID = \"BWI-Qs-d6i\";",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Writing Tools (Placeholder)"
+          }
+        }
+      },
+      "shouldTranslate" : false
+    },
     "BxI-nv-Xa5.title" : {
       "comment" : "Class = \"NSMenu\"; title = \"Table of Contents\"; ObjectID = \"BxI-nv-Xa5\";",
       "extractionState" : "extracted_with_value",
@@ -1717,6 +1730,19 @@
           }
         }
       }
+    },
+    "gSc-Jf-IPB.title" : {
+      "comment" : "Class = \"NSMenu\"; title = \"Writing Tools (Placeholder)\"; ObjectID = \"gSc-Jf-IPB\";",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Writing Tools (Placeholder)"
+          }
+        }
+      },
+      "shouldTranslate" : false
     },
     "gVA-U4-sdL.title" : {
       "comment" : "Class = \"NSMenuItem\"; title = \"Paste\"; ObjectID = \"gVA-U4-sdL\";",


### PR DESCRIPTION
WKWebView in macOS Golden Gate when `Siri AI` is enabled, currently shows neither `Writing Tools` nor `Ask Siri`, this should be a bug.

However in iOS 27 with `Siri AI` enabled, `Writing Tools` is intentionally hidden, this might be a design change.

This changes forces showing Writing Tools, no matter with bugs or design changes.