### PR TITLE
Improve titlebar introspecting

### DIFF
--- a/MarkEditMac/Modules/Sources/AppKitExtensions/UI/NSWindow+Extension.swift
+++ b/MarkEditMac/Modules/Sources/AppKitExtensions/UI/NSWindow+Extension.swift
@@ -7,38 +7,40 @@
 import AppKit
 
 public extension NSWindow {
-  var toolbarContainerView: NSView? {
-    toolbarRootView?.firstDescendant { (view: NSView) in
+
+  // MARK: - Hierarchy
+
+  /// Titlebar view under `NSTitlebarContainerView` that offers primary elements.
+  var titlebarView: NSView? {
+    titlebarContainerView?.firstDescendant { (view: NSView) in
       view.className == "NSTitlebarView"
     }
   }
 
-  // What we want is an NSVisualEffectView child of an NSTitlebarView
-  //
-  // In macOS Tahoe, it can also be an NSTitlebarBackgroundView for the modern style
-  var toolbarEffectView: NSView? {
-    // [macOS 26] Revisit this later (#1281)
-    for view in (toolbarContainerView?.subviews ?? []) {
-      if view is NSVisualEffectView || view.className == "NSTitlebarBackgroundView" {
-        return view
-      }
+  /// Decoration view under `NSTitlebarContainerView` that draws supplementary elements.
+  var titlebarDecorationView: NSView? {
+    titlebarContainerView?.firstDescendant { (view: NSView) in
+      view.className == "_NSTitlebarDecorationView" && view.subviews.isEmpty
     }
-
-    return nil
   }
 
-  var toolbarTitleView: NSView? {
-    toolbarContainerView?.firstDescendant { (view: NSView) in
+  /// Background effect view under `NSTitlebarContainerView` that offers blur or glassy effects.
+  ///
+  /// This can be under `NSTitlebarContainerView` or `NSTitlebarView`, depends on the system version.
+  var titlebarBackgroundView: NSView? {
+    titlebarContainerView?.firstDescendant { (view: NSView) in
+      view is NSVisualEffectView || view.className == "NSTitlebarBackgroundView"
+    }
+  }
+
+  /// Document title view under the `NSTitlebarView` that draws the document title.
+  var titlebarDocumentTitleView: NSView? {
+    titlebarView?.firstDescendant { (view: NSView) in
       view is NSTextField
     }
   }
 
-  /// The glassy or blurry background behind the titlebar, including the separator.
-  var titlebarDecorationView: NSView? {
-    toolbarRootView?.firstDescendant { (view: NSView) in
-      view.className == "_NSTitlebarDecorationView" && view.subviews.isEmpty
-    }
-  }
+  // MARK: - Convenience
 
   /// Change the frame size, treat the top-left corner as the anchor point.
   func setFrameSize(_ target: CGSize, display flag: Bool = false, animated: Bool = false) {
@@ -92,7 +94,7 @@ public extension NSWindow {
   ///
   /// There's no public API to programmatically show the menu assigned to an NSToolbarItem.
   func popUpButton(with menuIdentifier: NSUserInterfaceItemIdentifier) -> NSPopUpButton? {
-    toolbarRootView?.firstDescendant { (button: NSPopUpButton) in
+    titlebarContainerView?.firstDescendant { (button: NSPopUpButton) in
       button.menu?.identifier == menuIdentifier
     }
   }
@@ -101,7 +103,7 @@ public extension NSWindow {
   ///
   /// There's something called `NSToolbarItem.view`, it's non-nil only when we overwrite it.
   func toolbarButton(with itemIdentifier: NSToolbarItem.Identifier) -> NSButton? {
-    toolbarRootView?.firstDescendant { (button: NSButton) in
+    titlebarContainerView?.firstDescendant { (button: NSButton) in
       guard button.className == "NSToolbarButton" else {
         return false
       }
@@ -118,16 +120,18 @@ public extension NSWindow {
 // MARK: - Private
 
 private extension NSWindow {
-  var toolbarRootView: NSView? {
-    var node = toolbarHostingWindow.contentView
+  var titlebarContainerView: NSView? {
+    var node = currentHostingWindow.contentView
     while node?.superview != nil {
       node = node?.superview
     }
 
-    return node
+    return node?.firstDescendant { (view: NSView) in
+      view.className == "NSTitlebarContainerView"
+    }
   }
 
-  var toolbarHostingWindow: NSWindow {
+  var currentHostingWindow: NSWindow {
     guard NSApp.presentationOptions.contains(.fullScreen) else {
       return self
     }

--- a/MarkEditMac/Modules/Tests/RuntimeTests.swift
+++ b/MarkEditMac/Modules/Tests/RuntimeTests.swift
@@ -141,16 +141,22 @@ final class RuntimeTests: XCTestCase {
     XCTAssertNotNil(popover.value(forKey: "positioningView"))
   }
 
-  func testRetrievingToolbarEffectView() {
+  func testRetrievingTitlebarPrivateViews() {
     let window = NSWindow()
     window.makeKeyAndOrderFront(nil)
-    XCTAssertNotNil(window.toolbarEffectView)
+
+    XCTAssertNotNil(window.titlebarView)
+    XCTAssertNotNil(window.titlebarDecorationView)
+    XCTAssertNotNil(window.titlebarBackgroundView)
+    XCTAssertNotNil(window.titlebarDocumentTitleView)
   }
 
   func testPrivateAppKitClasses() {
     testExistenceOfClass(named: "_NSKeyboardFocusClipView")
     testExistenceOfClass(named: "_NSTitlebarDecorationView")
     testExistenceOfClass(named: "NSToolbarFullScreenWindow")
+    testExistenceOfClass(named: "NSTitlebarContainerView")
+    testExistenceOfClass(named: "NSTitlebarBackgroundView")
     testExistenceOfClass(named: "NSTitlebarView")
     testExistenceOfClass(named: "NSToolbarButton")
   }

--- a/MarkEditMac/Sources/Editor/Controllers/EditorViewController+Toolbar.swift
+++ b/MarkEditMac/Sources/Editor/Controllers/EditorViewController+Toolbar.swift
@@ -14,10 +14,14 @@ extension EditorViewController {
   }
 
   var statisticsSourceView: NSView? {
-    // Present the popover relative to the toolbar item
-    view.window?.toolbarButton(with: statisticsItem.itemIdentifier) ??
-    // Present the popover relative to the document title view
-    view.window?.toolbarTitleView
+    let sourceView =
+      // Relative to the toolbar item
+      view.window?.toolbarButton(with: statisticsItem.itemIdentifier) ??
+      // Relative to the document title view
+      view.window?.titlebarDocumentTitleView
+
+    Logger.assert(sourceView != nil, "Missing source view")
+    return sourceView
   }
 
   private enum Constants {
@@ -53,13 +57,17 @@ extension EditorViewController {
     }
 
     // Pop up the menu relative to the document title view
-    if let menu = (tableOfContentsItem as? NSMenuToolbarItem)?.menu,
-       let sourceView = view.window?.toolbarTitleView {
-      menu.popUp(
-        positioning: nil,
-        at: CGPoint(x: sourceView.bounds.minX, y: sourceView.bounds.maxY + 15),
-        in: sourceView
-      )
+    if let menu = (tableOfContentsItem as? NSMenuToolbarItem)?.menu {
+      if let sourceView = view.window?.titlebarDocumentTitleView {
+        menu.popUp(
+          positioning: nil,
+          at: CGPoint(x: sourceView.bounds.minX, y: sourceView.bounds.maxY + 15),
+          in: sourceView
+        )
+      } else {
+        Logger.assertFail("Missing document title view")
+      }
+
       return
     }
   }

--- a/MarkEditMac/Sources/Editor/Controllers/EditorViewController+UI.swift
+++ b/MarkEditMac/Sources/Editor/Controllers/EditorViewController+UI.swift
@@ -129,9 +129,12 @@ extension EditorViewController {
   }
 
   func updateWindowColors(_ theme: AppTheme) {
+    let titlebarView = view.window?.titlebarView
+    Logger.assert(titlebarView != nil, "Missing titlebar view")
+
     let backgroundColor = webBackgroundColor ?? theme.windowBackground
     view.window?.backgroundColor = backgroundColor
-    view.window?.toolbarContainerView?.layerBackgroundColor = backgroundColor
+    titlebarView?.layerBackgroundColor = backgroundColor
 
     let prefersTintedToolbar = theme.prefersTintedToolbar || backgroundColor.isTintedColor
     (view.window as? EditorWindow)?.prefersTintedToolbar = prefersTintedToolbar
@@ -143,7 +146,7 @@ extension EditorViewController {
       let baseColor = backgroundColor.withAlphaComponent(reduceTransparency ? 1.0 : 0.01)
 
       view.window?.backgroundColor = baseColor
-      view.window?.toolbarContainerView?.layerBackgroundColor = baseColor
+      titlebarView?.layerBackgroundColor = baseColor
 
       modernBackgroundView.layerBackgroundColor = backgroundColor
       modernEffectView.isHidden = reduceTransparency

--- a/MarkEditMac/Sources/Editor/EditorWindow.swift
+++ b/MarkEditMac/Sources/Editor/EditorWindow.swift
@@ -44,7 +44,7 @@ final class EditorWindow: NSWindow {
   }
 
   private var cachedToolbar: NSToolbar?
-  private weak var cachedToolbarEffectView: NSView?
+  private weak var cachedTitlebarBackgroundView: NSView?
   private weak var cachedTitlebarDecorationView: NSView?
 
   override func awakeFromNib() {
@@ -65,25 +65,27 @@ final class EditorWindow: NSWindow {
   /// Safe to call repeatedly; also runs implicitly after each layout pass.
   func updateTitleBarAppearance(clearCaches: Bool = true) {
     if clearCaches {
-      cachedToolbarEffectView = nil
+      cachedTitlebarBackgroundView = nil
       cachedTitlebarDecorationView = nil
     }
 
-    // The toolbar effect view also backs the auto-hiding titlebar overlay in
+    // The titlebar background view also backs the auto-hiding titlebar overlay in
     // fullscreen. When the toolbar is hidden, nothing else backs it, so keep
     // the effect view visible and fully opaque in that specific case to avoid
     // a transparent overlay.
-    if cachedToolbarEffectView == nil {
-      cachedToolbarEffectView = toolbarEffectView
+    if cachedTitlebarBackgroundView == nil {
+      cachedTitlebarBackgroundView = titlebarBackgroundView
     }
 
-    if let view = cachedToolbarEffectView {
+    if let view = cachedTitlebarBackgroundView {
       let needsOverlay = styleMask.contains(.fullScreen) && toolbarMode == .hidden
       view.alphaValue = needsOverlay ? 1 : (prefersTintedToolbar ? 0.3 : 0.7)
       view.isHidden = !needsOverlay && (reduceTransparency == true || AppDesign.modernTitleBar)
 
       // Blend the color of contents behind the window
       (view as? NSVisualEffectView)?.blendingMode = .behindWindow
+    } else {
+      Logger.assertFail("Missing cachedTitlebarBackgroundView")
     }
 
     if AppDesign.modernTitleBar {
@@ -104,6 +106,8 @@ final class EditorWindow: NSWindow {
           Logger.assertFail("Missing setDrawsBottomSeparator: in _NSTitlebarDecorationView")
           view.isHidden = true
         }
+      } else {
+        Logger.assertFail("Missing cachedTitlebarDecorationView")
       }
     }
   }


### PR DESCRIPTION
This PR exists for several reasons:

1. Handle titlebar view hierarchy change in macOS Golden Gate (`NSTitlebarBackgroundView` moved from `NSTitlebarView` to its parent `NSTitlebarContainerView`)
2. Resolve confusion naming between `titlebar` and `toolbar`, now `titlebar` is preferred, aligning private class names
3. Remove `toolbarRootView`, which starts view traversal from the root view (too pessimistic), now starts from `NSTitlebarContainerView`
4. Add assertion to catch missing views at runtime
5. Add more runtime unit tests

Tested affected scenarios in macOS Sequoia, Tahoe, and Golden Gate.