### PR TITLE
[macOS 27] Fix custom menu item image visibility

### DIFF
--- a/MarkEditMac/Modules/Sources/AppKitExtensions/UI/NSMenuItem+Extension.swift
+++ b/MarkEditMac/Modules/Sources/AppKitExtensions/UI/NSMenuItem+Extension.swift
@@ -56,6 +56,26 @@ public extension NSMenuItem {
 
     NSApp.sendAction(action, to: target, from: self)
   }
+
+  func ensureImageVisibility() {
+    guard #available(macOS 27.0, *) else {
+      return
+    }
+
+  #if canImport(FoundationModels, _version: 2)
+    preferredImageVisibility = .visible
+  #else
+    let selector = sel_getUid("setPreferredImageVisibility:")
+    if responds(to: selector) {
+      unsafeBitCast(
+        method(for: selector),
+        to: (@convention(c) (NSMenuItem, Selector, Int) -> Void).self
+      )(self, selector, 1) // .visible
+    } else {
+      assertionFailure("Missing setPreferredImageVisibility:")
+    }
+  #endif
+  }
 }
 
 extension NSControl.StateValue {

--- a/MarkEditMac/Sources/Editor/Controllers/EditorViewController+UI.swift
+++ b/MarkEditMac/Sources/Editor/Controllers/EditorViewController+UI.swift
@@ -508,6 +508,12 @@ extension EditorViewController {
 private extension EditorViewController {
   final class UserDefinedMenuItem: NSMenuItem {
     var stateGetterID: String?
+
+    override var image: NSImage? {
+      didSet {
+        ensureImageVisibility()
+      }
+    }
   }
 
   var contentHeight: Double {


### PR DESCRIPTION
This is a design change (rollback) in macOS Golden Gate, Apple did this revert by breaking apps.