### PR TITLE
Add Bullet/Numbered/Todo as individual toolbar items

### DIFF
--- a/MarkEditMac/Sources/Editor/Controllers/EditorViewController+Toolbar.swift
+++ b/MarkEditMac/Sources/Editor/Controllers/EditorViewController+Toolbar.swift
@@ -93,6 +93,9 @@ extension EditorViewController: NSToolbarDelegate {
       case .insertLink: return insertLinkItem
       case .insertImage: return insertImageItem
       case .toggleList: return toggleListItem
+      case .toggleBullet: return toggleBulletItem
+      case .toggleNumbering: return toggleNumberingItem
+      case .toggleTodo: return toggleTodoItem
       case .toggleBlockquote: return toggleBlockquoteItem
       case .horizontalRule: return horizontalRuleItem
       case .insertTable: return insertTableItem
@@ -215,6 +218,24 @@ private extension EditorViewController {
     ].compactMap { $0?.copiedItem }
 
     return .with(identifier: .toggleList, menu: menu)
+  }
+
+  var toggleBulletItem: NSToolbarItem {
+    .with(identifier: .toggleBullet) { [weak self] in
+      self?.toggleBullet(nil)
+    }
+  }
+
+  var toggleNumberingItem: NSToolbarItem {
+    .with(identifier: .toggleNumbering) { [weak self] in
+      self?.toggleNumbering(nil)
+    }
+  }
+
+  var toggleTodoItem: NSToolbarItem {
+    .with(identifier: .toggleTodo) { [weak self] in
+      self?.toggleTodo(nil)
+    }
   }
 
   var toggleBlockquoteItem: NSToolbarItem {

--- a/MarkEditMac/Sources/Editor/Models/EditorToolbarItems.swift
+++ b/MarkEditMac/Sources/Editor/Models/EditorToolbarItems.swift
@@ -91,6 +91,9 @@ extension NSToolbarItem.Identifier {
   static let insertLink = newItem("insertLink")
   static let insertImage = newItem("insertImage")
   static let toggleList = newItem("toggleList")
+  static let toggleBullet = newItem("toggleBullet")
+  static let toggleNumbering = newItem("toggleNumbering")
+  static let toggleTodo = newItem("toggleTodo")
   static let toggleBlockquote = newItem("toggleBlockquote")
   static let horizontalRule = newItem("horizontalRule")
   static let insertTable = newItem("insertTable")
@@ -121,6 +124,9 @@ extension NSToolbarItem.Identifier {
       .insertLink,
       .insertImage,
       .toggleList,
+      .toggleBullet,
+      .toggleNumbering,
+      .toggleTodo,
       .toggleBlockquote,
       .horizontalRule,
       .insertTable,
@@ -161,6 +167,9 @@ private extension NSToolbarItem.Identifier {
     case .insertLink: return Localized.Toolbar.insertLink
     case .insertImage: return Localized.Toolbar.insertImage
     case .toggleList: return Localized.Toolbar.toggleList
+    case .toggleBullet: return Localized.Toolbar.toggleBullet
+    case .toggleNumbering: return Localized.Toolbar.toggleNumbering
+    case .toggleTodo: return Localized.Toolbar.toggleTodo
     case .toggleBlockquote: return Localized.Toolbar.toggleBlockquote
     case .horizontalRule: return Localized.Toolbar.horizontalRule
     case .insertTable: return Localized.Toolbar.insertTable
@@ -184,6 +193,9 @@ private extension NSToolbarItem.Identifier {
     case .insertLink: return Icons.link
     case .insertImage: return Icons.photo
     case .toggleList: return Icons.listBullet
+    case .toggleBullet: return Icons.listBullet
+    case .toggleNumbering: return Icons.listNumber
+    case .toggleTodo: return Icons.checklist
     case .toggleBlockquote: return Icons.textQuote
     case .horizontalRule: return Icons.squareSplit1x2
     case .insertTable: return Icons.tablecells

--- a/MarkEditMac/Sources/Main/AppResources.swift
+++ b/MarkEditMac/Sources/Main/AppResources.swift
@@ -56,6 +56,9 @@ enum Localized {
     static let insertLink = String(localized: "Insert Link", comment: "Toolbar item to insert link")
     static let insertImage = String(localized: "Insert Image", comment: "Toolbar item to insert image")
     static let toggleList = String(localized: "Toggle List", comment: "Toolbar item to toggle bullet list")
+    static let toggleBullet = String(localized: "Bullet List", comment: "Toolbar item to toggle bullet list")
+    static let toggleNumbering = String(localized: "Numbered List", comment: "Toolbar item to toggle numbered list")
+    static let toggleTodo = String(localized: "Todo List", comment: "Toolbar item to toggle todo list")
     static let toggleBlockquote = String(localized: "Quote", comment: "Toolbar item to toggle blockquote")
     static let horizontalRule = String(localized: "Horizontal Rule", comment: "Toolbar item to insert horizontal rule")
     static let insertTable = String(localized: "Table", comment: "Toolbar item to insert table")
@@ -269,6 +272,8 @@ enum Icons {
   static let link = "link"
   static let listBullet = "list.bullet"
   static let listBulletRectangle = "list.bullet.rectangle"
+  static let listNumber = "list.number"
+  static let checklist = "checklist"
 
   static let numberSign = if #available(macOS 27.0, *) {
     "number.sign"


### PR DESCRIPTION
## Summary

The editor toolbar currently exposes list formatting only through the single combined **Toggle List** dropdown. This PR adds **Bullet List**, **Numbered List**, and **Todo List** as standalone, customizable toolbar items so that frequently used actions (Todo in particular) can be placed directly in the toolbar without opening the dropdown.

## What changed

- New toolbar item identifiers `toggleBullet`, `toggleNumbering`, `toggleTodo` (`EditorToolbarItems.swift`), each with a label and SF Symbol icon (`list.bullet`, `list.number`, `checklist`).
- Added to `allItems` so they appear in the **Customize Toolbar** palette. `defaultItems` is intentionally unchanged, so there is no change for existing users unless they opt in.
- Wired the three items to the existing `toggleBullet(_:)` / `toggleNumbering(_:)` / `toggleTodo(_:)` actions in `EditorViewController+Toolbar.swift`, matching the existing pattern used by `toggleBlockquote` and friends.
- New localized labels ("Bullet List", "Numbered List", "Todo List") in `AppResources.swift`.

The combined **Toggle List** dropdown is left in place, so this is purely additive.

## Notes

I was unable to compile locally (no full Xcode toolchain on my machine), but the changes mirror the existing standalone toolbar items line-for-line. A maintainer build/review is appreciated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)