### PR TITLE
Start Quick Look in Preview mode when a view-mode extension is installed

### DIFF
--- a/PreviewExtension/PreviewViewController.swift
+++ b/PreviewExtension/PreviewViewController.swift
@@ -28,6 +28,16 @@ final class PreviewViewController: NSViewController {
     // E.g., markedit-preview.js
     let controller = WKUserContentController()
     config.userContentController = controller
+
+    // If a view-mode extension (e.g. markedit-preview.js) is injected below, start it in
+    // Preview mode instead of showing raw source. This seeds the mode cache the extension
+    // reads on load; it's a harmless no-op when no such extension is present.
+    controller.addUserScript(WKUserScript(
+      source: "try { localStorage.setItem('ui.view-mode', '2') } catch {}",
+      injectionTime: .atDocumentStart,
+      forMainFrameOnly: false
+    ))
+
     userScripts.forEach {
       controller.addUserScript($0)
     }


### PR DESCRIPTION
## Summary

The Quick Look preview extension already injects the user's shared scripts (`Shared/scripts/*.js`) into its web view, so view-mode extensions such as [`markedit-preview`](https://github.com/MarkEdit-app/MarkEdit-preview) run inside Quick Look too. However they default to **Edit mode** (raw Markdown source) and only switch to a rendered **Preview** when their cached view-mode value is present.

This seeds that cached value at document start, so Quick Look (Finder spacebar) opens directly in **Preview mode** when such an extension is installed.

## Change

One `WKUserScript`, injected at `.atDocumentStart`, before the user scripts:

```swift
controller.addUserScript(WKUserScript(
  source: "try { localStorage.setItem('ui.view-mode', '2') } catch {}",
  injectionTime: .atDocumentStart,
  forMainFrameOnly: false
))
```

## Safety when no extension is installed

The snippet only writes a `localStorage` key. If no view-mode extension is present, nothing ever reads it — Quick Look shows the Markdown source exactly as before. The `try/catch` guards the edge case where storage is unavailable, so it cannot throw. There is no behavioral change and no error path for users without such an extension.

## Caveats (please read)

- This couples the preview extension to a **third-party extension's private storage key** (`ui.view-mode`, value `2` = preview). If the extension changes that key/enum, the effect silently stops (still no error).
- It is **always-on** when the extension is present; there's no per-file toggle. A settings gate isn't practical here because the Quick Look extension runs in its own sandbox and can't read the app's `settings.json`.

I understand if this is out of scope given MarkEdit intentionally shows source in Quick Look — opening it for discussion / in case others want the same. Not able to build locally (no full Xcode on this machine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)