### PR TITLE
Add public.utf8-plain-text to Markdown types

### DIFF
--- a/MarkEditMac/Info.plist
+++ b/MarkEditMac/Info.plist
@@ -157,6 +157,7 @@
 			<key>UTTypeConformsTo</key>
 			<array>
 				<string>public.plain-text</string>
+				<string>public.utf8-plain-text</string>
 			</array>
 			<key>UTTypeDescription</key>
 			<string>Markdown</string>
@@ -207,6 +208,7 @@
 			<key>UTTypeConformsTo</key>
 			<array>
 				<string>public.plain-text</string>
+				<string>public.utf8-plain-text</string>
 			</array>
 			<key>UTTypeDescription</key>
 			<string>Markdown</string>
@@ -226,6 +228,7 @@
 			<key>UTTypeConformsTo</key>
 			<array>
 				<string>public.plain-text</string>
+				<string>public.utf8-plain-text</string>
 			</array>
 			<key>UTTypeDescription</key>
 			<string>Markdown</string>


### PR DESCRIPTION
In macOS Golden Gate, Apple added `UTTypeMarkdown` as an official type and decided to let it conforms to `UTTypeUTF8PlainText`.

https://developer.apple.com/documentation/uniformtypeidentifiers/uttype-swift.struct/markdown