### PR TITLE
[macOS 26.6] Bypass cors restrictions in Quick Look

### DIFF
--- a/MarkEditKit/Sources/Extensions/WKWebViewConfiguration+Extension.swift
+++ b/MarkEditKit/Sources/Extensions/WKWebViewConfiguration+Extension.swift
@@ -12,7 +12,7 @@ public extension WKWebViewConfiguration {
     let config: WKWebViewConfiguration = .preferredConfig()
     config.enablePerformanceFlags(disabledFeatures: disabledFeatures)
 
-    // WebKit regression in macOS 26.6 that blocks url scheme tasks
+    // [macOS 26.6] WebKit regression that blocks url scheme tasks
     var corsDisablingPatterns = [
       "image-loader://*/*",
       "chunk-loader://*/*",

--- a/PreviewExtension/PreviewViewController.swift
+++ b/PreviewExtension/PreviewViewController.swift
@@ -25,6 +25,12 @@ final class PreviewViewController: NSViewController {
     config.enablePerformanceFlags()
     config.disableAllRichFeatures()
 
+    // [macOS 26.6] WebKit regression that blocks url scheme tasks
+    config.setObjectValue(
+      ["\(EditorImageLoader.scheme)://*/*"] as NSArray,
+      forSelector: "_setCORSDisablingPatterns:"
+    )
+
     // E.g., markedit-preview.js
     let controller = WKUserContentController()
     config.userContentController = controller


### PR DESCRIPTION
Similar to #1556.