### PR TITLE
Add inline Markdown image previews

### DIFF
--- a/CoreEditor/index.css
+++ b/CoreEditor/index.css
@@ -55,3 +55,22 @@ html, body {
   text-indent: 0px;
   margin-inline-start: 0px;
 }
+
+.cm-md-imagePreview {
+  display: inline-block;
+  max-inline-size: min(100%, 48rem);
+  margin-inline-start: 0.75em;
+  vertical-align: middle;
+}
+
+.cm-md-imagePreview[hidden] {
+  display: none;
+}
+
+.cm-md-imagePreviewImage {
+  display: block;
+  max-inline-size: 100%;
+  max-block-size: min(60vh, 36rem);
+  border-radius: 0.4em;
+  object-fit: contain;
+}

--- a/CoreEditor/src/styling/markdown.ts
+++ b/CoreEditor/src/styling/markdown.ts
@@ -9,6 +9,7 @@ import { inlineCodeStyle, codeBlockStyle, previewMermaid, previewMath } from './
 import { previewTable, tableStyle } from './nodes/table';
 import { frontMatterStyle } from './nodes/frontMatter';
 import { taskMarkerStyle } from './nodes/task';
+import { imagePreviewStyle } from './nodes/image';
 
 export const classHighlighters = [
   syntaxHighlighting(classHighlighter),
@@ -81,6 +82,7 @@ export const renderExtensions = [
   listIndentStyle,
   tableStyle,
   frontMatterStyle,
+  imagePreviewStyle,
 ];
 
 /**

--- a/CoreEditor/src/styling/nodes/image.ts
+++ b/CoreEditor/src/styling/nodes/image.ts
@@ -1,0 +1,246 @@
+import { EditorState } from '@codemirror/state';
+import { SyntaxNodeRef } from '@lezer/common';
+import { getSyntaxTree } from '../../modules/lezer';
+import { tryGetEditor } from '../../common/utils';
+import { createDecoPlugin } from '../helper';
+import { createWidgetDeco } from '../matchers/lezer';
+import { WidgetView } from '../views/types';
+
+const imageLoaderScheme = 'image-loader';
+
+type ImageInfo = {
+  alt: string;
+  destination: string;
+  title?: string;
+};
+
+/**
+ * Show an image directly after its Markdown source while keeping the source editable.
+ */
+export const imagePreviewStyle = createDecoPlugin(() => {
+  const state = window.editor.state;
+  let references: Map<string, string> | undefined;
+
+  return createWidgetDeco('Image', node => {
+    const info = imageInfo(node, state, () => {
+      references ??= referenceDestinations(state);
+      return references;
+    });
+    if (info === null) {
+      return null;
+    }
+
+    const source = imageSource(info.destination);
+    if (source.length === 0) {
+      return null;
+    }
+
+    return new ImagePreviewWidget(
+      source,
+      info.alt,
+      info.title,
+      node.to,
+    );
+  });
+});
+
+/**
+ * Use the native scheme handler for local files so relative paths resolve against
+ * the open document. Web resources can be loaded by WebKit as-is.
+ */
+export function imageSource(destination: string) {
+  const value = normalizeDestination(destination);
+  if (value.length === 0) {
+    return '';
+  }
+
+  if (value.startsWith('//')) {
+    return value;
+  }
+
+  if (value.startsWith('/')) {
+    return '';
+  }
+
+  const scheme = /^([a-z][a-z\d+.-]*):/i.exec(value)?.[1].toLowerCase();
+  if (scheme !== undefined) {
+    return ['http', 'https', 'data', 'blob', imageLoaderScheme].includes(scheme) ? value : '';
+  }
+
+  return `${imageLoaderScheme}://${encodeImagePath(value)}`;
+}
+
+export class ImagePreviewWidget extends WidgetView {
+  constructor(
+    private readonly source: string,
+    private readonly alt: string,
+    private readonly title: string | undefined,
+    pos: number,
+  ) {
+    super();
+    this.pos = pos;
+  }
+
+  toDOM() {
+    const wrapper = document.createElement('span');
+    wrapper.className = 'cm-md-imagePreview';
+    wrapper.hidden = true;
+
+    const image = wrapper.appendChild(document.createElement('img'));
+    image.className = 'cm-md-imagePreviewImage';
+    image.src = this.source;
+    image.alt = this.alt;
+    image.draggable = false;
+    image.decoding = 'async';
+
+    if (this.title !== undefined) {
+      image.title = this.title;
+    }
+
+    image.addEventListener('load', () => {
+      wrapper.hidden = false;
+      tryGetEditor()?.requestMeasure();
+    });
+
+    // The Markdown source remains visible, so a missing image needs no extra
+    // broken-image placeholder in the editor.
+    image.addEventListener('error', () => {
+      wrapper.hidden = true;
+      tryGetEditor()?.requestMeasure();
+    });
+
+    return wrapper;
+  }
+
+  eq(other: ImagePreviewWidget) {
+    return other.source === this.source
+      && other.alt === this.alt
+      && other.title === this.title
+      && other.pos === this.pos;
+  }
+
+  ignoreEvent() {
+    return true;
+  }
+}
+
+function imageInfo(
+  node: SyntaxNodeRef,
+  state: EditorState,
+  getReferences: () => Map<string, string>,
+): ImageInfo | null {
+  const marks = node.node.getChildren('LinkMark');
+  const closingAltMark = marks.find(mark => state.sliceDoc(mark.from, mark.to) === ']');
+  if (closingAltMark === undefined) {
+    return null;
+  }
+
+  const alt = unescapeMarkdown(state.sliceDoc(node.from + 2, closingAltMark.from));
+  const urlNode = node.node.getChild('URL');
+  const destination = urlNode === null
+    ? getReferences().get(referenceLabel(node, state, alt))
+    : state.sliceDoc(urlNode.from, urlNode.to);
+
+  if (destination === undefined || destination.length === 0) {
+    return null;
+  }
+
+  const titleNode = node.node.getChild('LinkTitle');
+  const title = titleNode === null
+    ? undefined
+    : unescapeMarkdown(stripTitleMarks(state.sliceDoc(titleNode.from, titleNode.to)));
+
+  return { alt, destination, title };
+}
+
+function referenceDestinations(state: EditorState) {
+  const references = new Map<string, string>();
+
+  getSyntaxTree(state).iterate({
+    from: 0,
+    to: state.doc.length,
+    enter: node => {
+      if (node.name === 'LinkDefinition') {
+        const label = node.node.getChild('LinkDefinitionID');
+        const line = state.doc.lineAt(node.to);
+        const match = state.sliceDoc(node.to, line.to).match(/^:\s*(?:<([^>]+)>|(\S+))/);
+        const destination = match?.[1] ?? match?.[2];
+        if (label !== null && destination !== undefined) {
+          addReference(references, state.sliceDoc(label.from, label.to), destination);
+        }
+        return;
+      }
+
+      if (node.name !== 'LinkReference') {
+        return;
+      }
+
+      const label = node.node.getChild('LinkLabel');
+      const url = node.node.getChild('URL');
+      if (label === null || url === null) {
+        return;
+      }
+
+      addReference(
+        references,
+        state.sliceDoc(label.from + 1, label.to - 1),
+        state.sliceDoc(url.from, url.to),
+      );
+    },
+  });
+
+  return references;
+}
+
+function addReference(references: Map<string, string>, label: string, destination: string) {
+  const key = normalizeReferenceLabel(label);
+  if (!references.has(key)) {
+    references.set(key, destination);
+  }
+}
+
+function referenceLabel(node: SyntaxNodeRef, state: EditorState, alt: string) {
+  const labelNode = node.node.getChild('LinkLabel');
+  const label = labelNode === null
+    ? alt
+    : state.sliceDoc(labelNode.from + 1, labelNode.to - 1) || alt;
+
+  return normalizeReferenceLabel(label);
+}
+
+function normalizeReferenceLabel(value: string) {
+  return unescapeMarkdown(value).trim().replace(/\s+/g, ' ').toLowerCase();
+}
+
+function normalizeDestination(destination: string) {
+  const value = destination.startsWith('<') && destination.endsWith('>')
+    ? destination.slice(1, -1)
+    : destination;
+
+  return unescapeMarkdown(value.trim());
+}
+
+function stripTitleMarks(title: string) {
+  const first = title.at(0);
+  const last = title.at(-1);
+  if ((first === '"' && last === '"')
+    || (first === '\'' && last === '\'')
+    || (first === '(' && last === ')')) {
+    return title.slice(1, -1);
+  }
+
+  return title;
+}
+
+function unescapeMarkdown(value: string) {
+  return value.replace(/\\([!"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~])/g, '$1');
+}
+
+function encodeImagePath(value: string) {
+  try {
+    return encodeURIComponent(decodeURIComponent(value));
+  } catch {
+    // A literal percent sign isn't a valid URL escape, but it can be part of a file name.
+    return encodeURIComponent(value);
+  }
+}

--- a/CoreEditor/test/image.test.ts
+++ b/CoreEditor/test/image.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, test } from '@jest/globals';
+import { imagePreviewStyle, imageSource } from '../src/styling/nodes/image';
+import { sleep } from './utils/helpers';
+import * as editor from './utils/editor';
+
+afterEach(() => {
+  window.editor.destroy();
+  document.body.innerHTML = '';
+});
+
+describe('Markdown image previews', () => {
+  test('renders an inline image after its editable source', async () => {
+    editor.setUp('Before ![Mountain view](images/morning.png "Morning") after', imagePreviewStyle);
+    await sleep(50);
+
+    const wrapper = document.querySelector<HTMLElement>('.cm-md-imagePreview');
+    const image = wrapper?.querySelector('img');
+
+    expect(wrapper).not.toBeNull();
+    expect(wrapper?.hidden).toBe(true);
+    expect(image?.getAttribute('src')).toBe('image-loader://images%2Fmorning.png');
+    expect(image?.alt).toBe('Mountain view');
+    expect(image?.title).toBe('Morning');
+    expect(editor.getText()).toBe('Before ![Mountain view](images/morning.png "Morning") after');
+
+    image?.dispatchEvent(new Event('load'));
+    expect(wrapper?.hidden).toBe(false);
+
+    image?.dispatchEvent(new Event('error'));
+    expect(wrapper?.hidden).toBe(true);
+  });
+
+  test('renders reference-style images', async () => {
+    editor.setUp('![Mountain][photo]\n\n[photo]: images/morning.png', imagePreviewStyle);
+    await sleep(50);
+
+    const image = document.querySelector<HTMLImageElement>('.cm-md-imagePreviewImage');
+    expect(image?.getAttribute('src')).toBe('image-loader://images%2Fmorning.png');
+    expect(image?.alt).toBe('Mountain');
+  });
+
+  test('does not render ordinary Markdown links', async () => {
+    editor.setUp('[Mountain](images/morning.png)', imagePreviewStyle);
+    await sleep(50);
+
+    expect(document.querySelector('.cm-md-imagePreview')).toBeNull();
+  });
+});
+
+describe('imageSource', () => {
+  test('routes relative file paths through the native loader', () => {
+    expect(imageSource('../Images/Morning View.png'))
+      .toBe('image-loader://..%2FImages%2FMorning%20View.png');
+  });
+
+  test('keeps remote and data sources intact', () => {
+    expect(imageSource('https://example.com/image.png')).toBe('https://example.com/image.png');
+    expect(imageSource('data:image/png;base64,abc')).toBe('data:image/png;base64,abc');
+    expect(imageSource('//example.com/image.png')).toBe('//example.com/image.png');
+    expect(imageSource('file:///Users/example/image.png')).toBe('');
+    expect(imageSource('javascript:alert(1)')).toBe('');
+  });
+
+  test('normalizes angle brackets and Markdown escapes', () => {
+    expect(imageSource('<images/Morning View.png>'))
+      .toBe('image-loader://images%2FMorning%20View.png');
+    expect(imageSource('images/Morning%20View.png'))
+      .toBe('image-loader://images%2FMorning%20View.png');
+    expect(imageSource('images/morning\\(final\\).png'))
+      .toBe('image-loader://images%2Fmorning(final).png');
+  });
+});

--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ For older macOS: [macos-12](https://github.com/MarkEdit-app/MarkEdit/releases/ta
 
 Please refer to the [wiki page](https://github.com/MarkEdit-app/MarkEdit/wiki/Manual) for details. Check out [MarkEdit-skill](https://github.com/MarkEdit-app/MarkEdit-skill) if you're interested in managing MarkEdit with an AI agent.
 
+### Inline image previews
+
+Markdown image references stay editable while MarkEdit displays their previews. Local image paths are resolved relative to the Markdown document, and standard inline and reference-style image syntax are supported.
+
 ## Why MarkEdit is free
 
 MarkEdit is a tool we use every day and keep improving for ourselves. We ship it openly, hoping it's useful to others with the same needs.


### PR DESCRIPTION
## Summary

Adds inline image previews to MarkEdit while preserving the original Markdown source for editing.

- Render local relative images, remote HTTPS images, data URLs, and reference-style image syntax
- Keep previews responsive and hide failed loads without broken-image clutter
- Enable the same rendering in the full editor and Quick Look preview
- Document supported image references in the README

## Why

Markdown image references currently remain source-only, forcing users to open a separate preview to confirm local assets. Rendering a compact inline preview improves writing and review without introducing non-standard Markdown.

## Validation

- corepack yarn build
- corepack yarn test --runInBand — 173 tests passed
- Focused coverage for inline and reference images, alt/title propagation, missing images, URL resolution, and unsafe scheme rejection

## Checklist

- [x] I have followed the [development guide](https://github.com/MarkEdit-app/MarkEdit/wiki/Development) and matched the existing code style
- [x] I have performed a self-review of my own code, kept the diff minimal, and avoided unrelated changes
- [x] I have smoke tested the change, covering the main affected paths
- [x] For user-visible strings: localization keys have been added/updated as needed (no new user-visible strings were introduced)
- [x] For UI changes: I have attached before/after screenshots or a short screen recording

## Screenshots

The screenshots use the same Markdown image reference in CoreEditor development builds. The first is upstream main; the second is this branch.

**Before (upstream main)**

![Before: Markdown source with no inline image preview](https://raw.githubusercontent.com/adammenges/MarkEdit/codex/inline-image-preview-evidence/.github/pr-evidence/inline-image-preview-before.jpg)

**After (this branch)**

![After: Markdown source with an inline image preview](https://raw.githubusercontent.com/adammenges/MarkEdit/codex/inline-image-preview-evidence/.github/pr-evidence/inline-image-preview-after.jpg)