### PR TITLE
Add Japanese localization

### DIFF
--- a/MarkEdit.xcodeproj/project.pbxproj
+++ b/MarkEdit.xcodeproj/project.pbxproj
@@ -713,6 +713,7 @@
 			knownRegions = (
 				en,
 				Base,
+				ja,
 				"zh-Hans",
 				"zh-Hant",
 			);

--- a/MarkEditMac/AppShortcuts.xcstrings
+++ b/MarkEditMac/AppShortcuts.xcstrings
@@ -29,9 +29,11 @@
           }
         },
         "ja" : {
-          "stringUnit" : {
+          "stringSet" : {
             "state" : "translated",
-            "value" : "${applicationName}で新規書類を作成"
+            "values" : [
+              "${applicationName}で新規書類を作成"
+            ]
           }
         }
       }
@@ -64,9 +66,11 @@
           }
         },
         "ja" : {
-          "stringUnit" : {
+          "stringSet" : {
             "state" : "translated",
-            "value" : "${applicationName}でJavaScriptを評価"
+            "values" : [
+              "${applicationName}でJavaScriptを評価"
+            ]
           }
         }
       }
@@ -99,9 +103,11 @@
           }
         },
         "ja" : {
-          "stringUnit" : {
+          "stringSet" : {
             "state" : "translated",
-            "value" : "${applicationName}でファイルの内容を取得"
+            "values" : [
+              "${applicationName}でファイルの内容を取得"
+            ]
           }
         }
       }
@@ -134,9 +140,11 @@
           }
         },
         "ja" : {
-          "stringUnit" : {
+          "stringSet" : {
             "state" : "translated",
-            "value" : "${applicationName}でファイルの内容を更新"
+            "values" : [
+              "${applicationName}でファイルの内容を更新"
+            ]
           }
         }
       }

--- a/MarkEditMac/AppShortcuts.xcstrings
+++ b/MarkEditMac/AppShortcuts.xcstrings
@@ -27,6 +27,12 @@
               "在 ${applicationName} 中建立新文件"
             ]
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "${applicationName}で新規書類を作成"
+          }
         }
       }
     },
@@ -55,6 +61,12 @@
             "values" : [
               "在 ${applicationName} 中執行 JavaScript"
             ]
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "${applicationName}でJavaScriptを評価"
           }
         }
       }
@@ -85,6 +97,12 @@
               "在 ${applicationName} 中獲取檔案內容"
             ]
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "${applicationName}でファイルの内容を取得"
+          }
         }
       }
     },
@@ -113,6 +131,12 @@
             "values" : [
               "在 ${applicationName} 中更新檔案內容"
             ]
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "${applicationName}でファイルの内容を更新"
           }
         }
       }

--- a/MarkEditMac/Resources/Localizable.xcstrings
+++ b/MarkEditMac/Resources/Localizable.xcstrings
@@ -19,7 +19,7 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "**作者:** %@"
+            "value" : "**作成者:** %@"
           }
         }
       }
@@ -337,7 +337,7 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "アクティブ行インジケータ"
+            "value" : "現在の行を強調表示"
           }
         }
       }
@@ -1510,7 +1510,7 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "${content}を使用してJavaScriptを評価"
+            "value" : "${content}を使ってJavaScriptを評価"
           }
         }
       }
@@ -1693,7 +1693,7 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ファイル拡張子:"
+            "value" : "拡張子:"
           }
         }
       }
@@ -1784,7 +1784,7 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "選択部分を検索"
+            "value" : "選択部分を検索に使用"
           }
         }
       }
@@ -2139,7 +2139,7 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "適用範囲"
+            "value" : "更新範囲"
           }
         }
       }
@@ -2995,7 +2995,7 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "MarkEdit %@を利用できます!"
+            "value" : "MarkEdit %@が利用可能です!"
           }
         }
       }
@@ -3063,7 +3063,7 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "続行するためのアクティブな書類がありません。"
+            "value" : "続行するには、アクティブな書類が必要です。"
           }
         }
       }
@@ -3177,7 +3177,7 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "${initialContent}を使用して${fileName}という名前の新規書類を作成"
+            "value" : "${fileName}という名前で新規書類を作成し、内容を${initialContent}に設定"
           }
         }
       }
@@ -3594,7 +3594,7 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "優先するインデント:"
+            "value" : "インデント単位:"
           }
         }
       }
@@ -3916,7 +3916,7 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "再度開く"
+            "value" : "再起動"
           }
         }
       }
@@ -3939,7 +3939,7 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "“%@”の使用を開始するにはMarkEditを再度開いてください。"
+            "value" : "“%@”の使用を開始するにはMarkEditを再起動してください。"
           }
         }
       }
@@ -3962,7 +3962,7 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "アップデートした機能拡張を使用するにはMarkEditを再度開いてください。"
+            "value" : "アップデートした機能拡張を使用するにはMarkEditを再起動してください。"
           }
         }
       }
@@ -3985,7 +3985,7 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "変更を適用するにはアプリを再度開いてください。"
+            "value" : "変更を適用するにはMarkEditを再起動してください。"
           }
         }
       }
@@ -4444,7 +4444,7 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "選択状況"
+            "value" : "選択範囲の情報"
           }
         }
       }
@@ -4536,7 +4536,7 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "不可視ファイルを表示"
+            "value" : "隠しファイルを表示"
           }
         }
       }
@@ -4697,7 +4697,7 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "機能拡張を提出…"
+            "value" : "機能拡張を登録…"
           }
         }
       }
@@ -4766,7 +4766,7 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "システムデフォルト"
+            "value" : "システム標準"
           }
         }
       }
@@ -5111,7 +5111,7 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "スクリプトフォルダからこの機能拡張のスクリプトが削除されます。"
+            "value" : "この機能拡張のスクリプトがスクリプトフォルダから削除されます。"
           }
         }
       }
@@ -5502,7 +5502,7 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "アップデート動作"
+            "value" : "アップデート方法"
           }
         }
       }
@@ -5547,7 +5547,7 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "${content}でファイルを更新"
+            "value" : "ファイルの内容を${content}に更新"
           }
         }
       }
@@ -5942,7 +5942,7 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "最新です!"
+            "value" : "最新の状態です!"
           }
         }
       }

--- a/MarkEditMac/Resources/Localizable.xcstrings
+++ b/MarkEditMac/Resources/Localizable.xcstrings
@@ -15,6 +15,12 @@
             "state" : "translated",
             "value" : "**作者：**%@"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**作者:** %@"
+          }
         }
       }
     },
@@ -31,6 +37,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "**連結：**%@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**URL:** %@"
           }
         }
       }
@@ -51,6 +63,12 @@
           }
         },
         "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$d/%2$d"
+          }
+        },
+        "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$d/%2$d"
@@ -102,6 +120,18 @@
               }
             }
           }
+        },
+        "ja" : {
+          "variations" : {
+            "plural" : {
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld個の機能拡張"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -118,6 +148,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "⌘ 點選以跟隨"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "⌘キーを押しながらクリックしてリンクを開く"
           }
         }
       }
@@ -136,6 +172,12 @@
             "state" : "translated",
             "value" : "⌘ 點選切換完成狀態"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "⌘キーを押しながらクリックしてToDoを切り替える"
+          }
         }
       }
     },
@@ -152,6 +194,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "🎉 %@ 已釋出"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "🎉 %@がリリースされました"
           }
         }
       }
@@ -170,6 +218,12 @@
             "state" : "translated",
             "value" : "1 個制表符"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タブ1個"
+          }
         }
       }
     },
@@ -186,6 +240,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "2 個空格"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "スペース2個"
           }
         }
       }
@@ -204,6 +264,12 @@
             "state" : "translated",
             "value" : "2 個制表符"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タブ2個"
+          }
         }
       }
     },
@@ -220,6 +286,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "4 個空格"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "スペース4個"
           }
         }
       }
@@ -238,6 +310,12 @@
             "state" : "translated",
             "value" : "操作"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アクション"
+          }
         }
       }
     },
@@ -254,6 +332,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "當前行指示器"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アクティブ行インジケータ"
           }
         }
       }
@@ -272,6 +356,12 @@
             "state" : "translated",
             "value" : "全部"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "すべて"
+          }
         }
       }
     },
@@ -287,6 +377,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "允許程式碼執行返回一個 Promise 物件。啟用時，JavaScript 程式碼必須返回一個值。"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "評価結果としてPromiseオブジェクトを返せるようにします。有効にした場合、JavaScriptは値を返す必要があります。"
           }
         }
       }
@@ -305,6 +401,12 @@
             "state" : "translated",
             "value" : "總是"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "常に"
+          }
         }
       }
     },
@@ -321,6 +423,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "外觀："
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外観:"
           }
         }
       }
@@ -339,6 +447,12 @@
             "state" : "translated",
             "value" : "在事件描述符中找不到引數“%@”，該描述符可能格式不正確。"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "イベント記述子に引数“%@”が見つかりません。記述子が不正である可能性があります。"
+          }
         }
       }
     },
@@ -355,6 +469,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "更新前詢問"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アップデート前に確認"
           }
         }
       }
@@ -373,6 +493,12 @@
             "state" : "translated",
             "value" : "輔助"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アシスタント"
+          }
         }
       }
     },
@@ -390,6 +516,12 @@
             "state" : "translated",
             "value" : "自動補全："
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動補完:"
+          }
         }
       }
     },
@@ -403,6 +535,12 @@
           }
         },
         "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動"
+          }
+        },
+        "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "自動"
@@ -424,6 +562,12 @@
             "state" : "translated",
             "value" : "粗體"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ボールド"
+          }
         }
       }
     },
@@ -439,6 +583,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "呼叫非同步 JavaScript"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "非同期JavaScriptを呼び出す"
           }
         }
       }
@@ -456,6 +606,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "取消"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キャンセル"
           }
         }
       }
@@ -480,6 +636,12 @@
             "state" : "translated",
             "value" : "不支援匯出“%1$@”格式的檔案，支援的格式：%2$@。"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "拡張子“%1$@”のファイルは書き出せません。対応している拡張子: %2$@。"
+          }
         }
       }
     },
@@ -496,6 +658,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "大小寫敏感"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "大文字/小文字を区別"
           }
         }
       }
@@ -514,6 +682,12 @@
             "state" : "translated",
             "value" : "字元數量"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文字数"
+          }
         }
       }
     },
@@ -530,6 +704,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "檢查版本記錄"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "バージョン履歴を確認"
           }
         }
       }
@@ -548,6 +728,12 @@
             "state" : "translated",
             "value" : "Classic Mac OS (CR)"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Classic Mac OS（CR）"
+          }
         }
       }
     },
@@ -564,6 +750,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "清除最近"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最近の検索を消去"
           }
         }
       }
@@ -582,6 +774,12 @@
             "state" : "translated",
             "value" : "欄"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "列"
+          }
         }
       }
     },
@@ -598,6 +796,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "註解"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "コメント数"
           }
         }
       }
@@ -616,6 +820,12 @@
             "state" : "translated",
             "value" : "緊湊"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "コンパクト"
+          }
         }
       }
     },
@@ -633,6 +843,12 @@
             "state" : "translated",
             "value" : "單字補全："
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "補完:"
+          }
         }
       }
     },
@@ -648,6 +864,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "內容"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "内容"
           }
         }
       }
@@ -666,6 +888,12 @@
             "state" : "translated",
             "value" : "控制字元"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "制御文字"
+          }
         }
       }
     },
@@ -682,6 +910,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "拷貝 Pandoc 指令"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pandocコマンドをコピー"
           }
         }
       }
@@ -700,6 +934,12 @@
             "state" : "translated",
             "value" : "找不到用於處理接收到 Apple Event 的指令。"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "受信したApple Eventを処理するコマンドが見つかりません。"
+          }
         }
       }
     },
@@ -716,6 +956,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "在擴充功能目錄中找不到“%@”。"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "レジストリに機能拡張“%@”が見つかりませんでした。"
           }
         }
       }
@@ -734,6 +980,12 @@
             "state" : "translated",
             "value" : "無法連接擴充功能目錄。"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "機能拡張レジストリに接続できませんでした。"
+          }
         }
       }
     },
@@ -750,6 +1002,12 @@
             "state" : "translated",
             "value" : "建立新文件"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新規書類を作成"
+          }
         }
       }
     },
@@ -765,6 +1023,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "新建一個文件，可透過可選變數來設定檔案名和初始內容。"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ファイル名と初期内容をオプションで指定して、新しい書類を作成します。"
           }
         }
       }
@@ -783,6 +1047,12 @@
             "state" : "translated",
             "value" : "深色"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ダーク"
+          }
         }
       }
     },
@@ -799,6 +1069,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "深色主題："
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ダークテーマ:"
           }
         }
       }
@@ -817,6 +1093,12 @@
             "state" : "translated",
             "value" : "預設行尾格式："
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "デフォルトの改行コード:"
+          }
         }
       }
     },
@@ -833,6 +1115,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "預設文字編碼："
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "デフォルトのテキストエンコーディング:"
           }
         }
       }
@@ -851,6 +1139,12 @@
             "state" : "translated",
             "value" : "刪除"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "削除"
+          }
         }
       }
     },
@@ -867,6 +1161,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "忽略變音符"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "発音区別符号を区別しない"
           }
         }
       }
@@ -885,6 +1185,12 @@
             "state" : "translated",
             "value" : "按字元對比"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文字単位の差分"
+          }
         }
       }
     },
@@ -901,6 +1207,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "按行對比"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "行単位の差分"
           }
         }
       }
@@ -919,6 +1231,12 @@
             "state" : "translated",
             "value" : "按單詞對比"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "単語単位の差分"
+          }
         }
       }
     },
@@ -935,6 +1253,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "淡化非當前行"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "非アクティブな行を暗くする"
           }
         }
       }
@@ -953,6 +1277,12 @@
             "state" : "translated",
             "value" : "禁止更新檢查"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アップデートの確認を無効にする"
+          }
         }
       }
     },
@@ -969,6 +1299,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "禁止"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "許可しない"
           }
         }
       }
@@ -987,6 +1323,12 @@
             "state" : "translated",
             "value" : "發現"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "見つける"
+          }
         }
       }
     },
@@ -1003,6 +1345,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "全文件"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "書類"
           }
         }
       }
@@ -1021,6 +1369,12 @@
             "state" : "translated",
             "value" : "完成"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完了"
+          }
         }
       }
     },
@@ -1037,6 +1391,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "編輯行為："
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "編集動作:"
           }
         }
       }
@@ -1055,6 +1415,12 @@
             "state" : "translated",
             "value" : "編輯器"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "エディタ"
+          }
         }
       }
     },
@@ -1071,6 +1437,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已啟用"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "有効"
           }
         }
       }
@@ -1089,6 +1461,12 @@
             "state" : "translated",
             "value" : "輸入行號並按下回車鍵"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "行番号を入力してReturnキーを押してください"
+          }
         }
       }
     },
@@ -1104,6 +1482,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "執行 JavaScript"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "JavaScriptを評価"
           }
         }
       }
@@ -1122,6 +1506,12 @@
             "state" : "translated",
             "value" : "使用 ${content} 執行 JavaScript"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "${content}を使用してJavaScriptを評価"
+          }
         }
       }
     },
@@ -1137,6 +1527,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "在當前活躍文件執行 JavaScript 並獲取結果，沒有開啟的編輯器時將丟擲異常。"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アクティブな書類でJavaScriptを評価し、結果を取得します。エディタが開いていない場合はエラーになります。"
           }
         }
       }
@@ -1155,6 +1551,12 @@
             "state" : "translated",
             "value" : "擴充功能已安裝"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "機能拡張がインストールされました"
+          }
         }
       }
     },
@@ -1171,6 +1573,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "有可用的擴充功能更新"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "機能拡張のアップデートがあります"
           }
         }
       }
@@ -1189,6 +1597,12 @@
             "state" : "translated",
             "value" : "擴充功能已更新"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "機能拡張がアップデートされました"
+          }
         }
       }
     },
@@ -1205,6 +1619,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "無法獲取更新。"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アップデートを取得できませんでした。"
           }
         }
       }
@@ -1223,6 +1643,12 @@
             "state" : "translated",
             "value" : "無法安裝該擴充功能。"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "機能拡張をインストールできませんでした。"
+          }
         }
       }
     },
@@ -1239,6 +1665,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "精選"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "おすすめ"
           }
         }
       }
@@ -1257,6 +1689,12 @@
             "state" : "translated",
             "value" : "檔案副檔名："
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ファイル拡張子:"
+          }
         }
       }
     },
@@ -1272,6 +1710,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "檔案名"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ファイル名"
           }
         }
       }
@@ -1290,6 +1734,12 @@
             "state" : "translated",
             "value" : "檔案大小"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ファイルサイズ"
+          }
         }
       }
     },
@@ -1306,6 +1756,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "尋找"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "検索"
           }
         }
       }
@@ -1324,6 +1780,12 @@
             "state" : "translated",
             "value" : "尋找選中內容"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選択部分を検索"
+          }
         }
       }
     },
@@ -1340,6 +1802,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "折疊行"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "行を折りたたむ"
           }
         }
       }
@@ -1358,6 +1826,12 @@
             "state" : "translated",
             "value" : "折疊的程式碼"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "折りたたまれたコード"
+          }
         }
       }
     },
@@ -1374,6 +1848,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "折疊的行"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "折りたたまれた行"
           }
         }
       }
@@ -1392,6 +1872,12 @@
             "state" : "translated",
             "value" : "字體："
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "フォント:"
+          }
         }
       }
     },
@@ -1409,6 +1895,12 @@
             "state" : "translated",
             "value" : "格式化檔案："
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ファイルの整形:"
+          }
         }
       }
     },
@@ -1425,6 +1917,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "儲存時進行格式化。"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ファイルの保存時に整形します。"
           }
         }
       }
@@ -1473,6 +1971,18 @@
               }
             }
           }
+        },
+        "ja" : {
+          "variations" : {
+            "plural" : {
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld個のバージョンが見つかりました。削除しますか?"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -1486,6 +1996,12 @@
           }
         },
         "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一般"
+          }
+        },
+        "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "一般"
@@ -1507,6 +2023,12 @@
             "state" : "translated",
             "value" : "獲取自訂主題…"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "カスタムテーマを入手…"
+          }
         }
       }
     },
@@ -1523,6 +2045,12 @@
             "state" : "translated",
             "value" : "獲取檔案內容"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ファイルの内容を取得"
+          }
         }
       }
     },
@@ -1538,6 +2066,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "獲取當前活躍檔案的內容，沒有開啟的編輯器時將丟擲異常。"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アクティブな書類のファイル内容を取得します。エディタが開いていない場合はエラーになります。"
           }
         }
       }
@@ -1556,6 +2090,12 @@
             "state" : "translated",
             "value" : "跳轉到行"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "指定行へ移動"
+          }
         }
       }
     },
@@ -1573,6 +2113,12 @@
             "state" : "translated",
             "value" : "授予許可權"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アクセスを許可"
+          }
         }
       }
     },
@@ -1588,6 +2134,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "粒度"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "適用範囲"
           }
         }
       }
@@ -1606,6 +2158,12 @@
             "state" : "translated",
             "value" : "猜測的單字"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "推測された単語"
+          }
         }
       }
     },
@@ -1622,6 +2180,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "標題"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "見出し"
           }
         }
       }
@@ -1640,6 +2204,12 @@
             "state" : "translated",
             "value" : "隱藏"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "非表示"
+          }
         }
       }
     },
@@ -1656,6 +2226,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "首頁"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ホームページ"
           }
         }
       }
@@ -1674,6 +2250,12 @@
             "state" : "translated",
             "value" : "水平分割線"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "水平線"
+          }
         }
       }
     },
@@ -1691,6 +2273,12 @@
             "state" : "translated",
             "value" : "增加縮排"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "インデントを増やす"
+          }
         }
       }
     },
@@ -1706,6 +2294,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "初始內容"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "初期内容"
           }
         }
       }
@@ -1724,6 +2318,12 @@
             "state" : "translated",
             "value" : "預測字詞"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "インライン予測"
+          }
         }
       }
     },
@@ -1740,6 +2340,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "插入程式碼"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "コードを挿入"
           }
         }
       }
@@ -1758,6 +2364,12 @@
             "state" : "translated",
             "value" : "插入最終換行"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "末尾に改行を挿入"
+          }
         }
       }
     },
@@ -1774,6 +2386,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "插入圖片"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "画像を挿入"
           }
         }
       }
@@ -1792,6 +2410,12 @@
             "state" : "translated",
             "value" : "插入換行符"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "改行を挿入"
+          }
         }
       }
     },
@@ -1808,6 +2432,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "插入連結"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リンクを挿入"
           }
         }
       }
@@ -1826,6 +2456,12 @@
             "state" : "translated",
             "value" : "插入制表符"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タブを挿入"
+          }
         }
       }
     },
@@ -1842,6 +2478,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "插入 2 個空格"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "スペース2個を挿入"
           }
         }
       }
@@ -1860,6 +2502,12 @@
             "state" : "translated",
             "value" : "插入 4 個空格"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "スペース4個を挿入"
+          }
         }
       }
     },
@@ -1876,6 +2524,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "插入制表符"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タブ文字を挿入"
           }
         }
       }
@@ -1894,6 +2548,12 @@
             "state" : "translated",
             "value" : "安裝"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "インストール"
+          }
         }
       }
     },
@@ -1910,6 +2570,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "要安裝“%@”嗎？"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "“%@”をインストールしますか?"
           }
         }
       }
@@ -1928,6 +2594,12 @@
             "state" : "translated",
             "value" : "從 URL 安裝擴充功能"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URLから機能拡張をインストール"
+          }
         }
       }
     },
@@ -1944,6 +2616,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "從 URL 安裝…"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URLからインストール…"
           }
         }
       }
@@ -1962,6 +2640,12 @@
             "state" : "translated",
             "value" : "已安裝"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "インストール済み"
+          }
         }
       }
     },
@@ -1979,6 +2663,12 @@
             "state" : "translated",
             "value" : "斜體"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "イタリック"
+          }
         }
       }
     },
@@ -1992,6 +2682,12 @@
           }
         },
         "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "項目"
+          }
+        },
+        "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "項目"
@@ -2019,6 +2715,12 @@
             "state" : "translated",
             "value" : "JavaScript 執行在第 %1$d 行，第 %2$d 欄失敗：%3$@"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "JavaScriptの評価に失敗しました（%1$d行、%2$d列）: %3$@"
+          }
         }
       }
     },
@@ -2035,6 +2737,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "JavaScript 執行因未知原因失敗。"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不明な理由でJavaScriptの評価に失敗しました。"
           }
         }
       }
@@ -2053,6 +2761,12 @@
             "state" : "translated",
             "value" : "保持游標居中"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キャレットを中央に保つ"
+          }
         }
       }
     },
@@ -2069,6 +2783,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "稍後"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "あとで"
           }
         }
       }
@@ -2087,6 +2807,12 @@
             "state" : "translated",
             "value" : "浅色"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ライト"
+          }
         }
       }
     },
@@ -2103,6 +2829,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "淺色主題："
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ライトテーマ:"
           }
         }
       }
@@ -2121,6 +2853,12 @@
             "state" : "translated",
             "value" : "行高："
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "行の高さ:"
+          }
         }
       }
     },
@@ -2137,6 +2875,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "行號"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "行番号"
           }
         }
       }
@@ -2155,6 +2899,12 @@
             "state" : "translated",
             "value" : "自動折行："
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "行の折り返し:"
+          }
         }
       }
     },
@@ -2171,6 +2921,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "字面尋找"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リテラル検索"
           }
         }
       }
@@ -2189,6 +2945,12 @@
             "state" : "translated",
             "value" : "本機"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ローカル"
+          }
         }
       }
     },
@@ -2205,6 +2967,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "macOS / Unix (LF)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "macOS / Unix（LF）"
           }
         }
       }
@@ -2223,6 +2991,12 @@
             "state" : "translated",
             "value" : "MarkEdit %@ 已釋出！"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "MarkEdit %@を利用できます!"
+          }
         }
       }
     },
@@ -2239,6 +3013,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "MarkEdit %@ 是目前的最新版本。"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "MarkEdit %@は現在の最新バージョンです。"
           }
         }
       }
@@ -2257,6 +3037,12 @@
             "state" : "translated",
             "value" : "MarkEdit 擴充功能"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "MarkEdit機能拡張"
+          }
         }
       }
     },
@@ -2272,6 +3058,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "沒有活躍的文件來進行下一步。"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "続行するためのアクティブな書類がありません。"
           }
         }
       }
@@ -2290,6 +3082,12 @@
             "state" : "translated",
             "value" : "更多字型"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "その他のフォント"
+          }
         }
       }
     },
@@ -2306,6 +3104,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "從不"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "しない"
           }
         }
       }
@@ -2324,6 +3128,12 @@
             "state" : "translated",
             "value" : "從不檢查"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "確認しない"
+          }
         }
       }
     },
@@ -2341,6 +3151,12 @@
             "state" : "translated",
             "value" : "新增文件"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新規書類"
+          }
         }
       }
     },
@@ -2356,6 +3172,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "以 ${initialContent} 新增名為 ${fileName} 的文件"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "${initialContent}を使用して${fileName}という名前の新規書類を作成"
           }
         }
       }
@@ -2374,6 +3196,12 @@
             "state" : "translated",
             "value" : "新檔案副檔名："
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新しいファイル名拡張子:"
+          }
         }
       }
     },
@@ -2390,6 +3218,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "新視窗行為："
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新規ウインドウの動作:"
           }
         }
       }
@@ -2408,6 +3242,12 @@
             "state" : "translated",
             "value" : "下一個"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "次へ"
+          }
         }
       }
     },
@@ -2424,6 +3264,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "找不到用於文件“%@”的編輯器。"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "書類“%@”のエディタが見つかりません。"
           }
         }
       }
@@ -2442,6 +3288,12 @@
             "state" : "translated",
             "value" : "未找到擴充功能。"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "機能拡張が見つかりません。"
+          }
         }
       }
     },
@@ -2458,6 +3310,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "未安裝擴充功能。"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "機能拡張がインストールされていません。"
           }
         }
       }
@@ -2476,6 +3334,12 @@
             "state" : "translated",
             "value" : "沒有可用更新。"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "利用可能なアップデートはありません。"
+          }
         }
       }
     },
@@ -2492,6 +3356,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "沒有符合條件的版本。"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "指定した条件に一致するバージョンはありません。"
           }
         }
       }
@@ -2510,6 +3380,12 @@
             "state" : "translated",
             "value" : "正常"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "標準"
+          }
         }
       }
     },
@@ -2526,6 +3402,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "等下再說"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "今はしない"
           }
         }
       }
@@ -2544,6 +3426,12 @@
             "state" : "translated",
             "value" : "官方"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "公式"
+          }
         }
       }
     },
@@ -2560,6 +3448,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "官方網站"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "公式Webサイト"
           }
         }
       }
@@ -2578,6 +3472,12 @@
             "state" : "translated",
             "value" : "打開文件"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "書類を開く"
+          }
         }
       }
     },
@@ -2595,6 +3495,12 @@
             "state" : "translated",
             "value" : "打開字體面板…"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "フォントパネルを開く…"
+          }
         }
       }
     },
@@ -2611,6 +3517,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "打開指令碼目錄"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "スクリプトフォルダを開く"
           }
         }
       }
@@ -2632,6 +3544,12 @@
             "state" : "translated",
             "value" : "段落數量"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "段落数"
+          }
         }
       }
     },
@@ -2648,6 +3566,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "請檢查您的網路連線，或從版本記錄中獲取最新版本。"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ネットワーク接続を確認するか、バージョン履歴から最新リリースを入手してください。"
           }
         }
       }
@@ -2666,6 +3590,12 @@
             "state" : "translated",
             "value" : "縮排偏好："
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "優先するインデント:"
+          }
         }
       }
     },
@@ -2682,6 +3612,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "首選"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "優先"
           }
         }
       }
@@ -2700,6 +3636,12 @@
             "state" : "translated",
             "value" : "按下 ⌥ ⎋ 來顯示列表。"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "⌥ ⎋キーでパネルを表示します。"
+          }
         }
       }
     },
@@ -2716,6 +3658,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "預覽"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "プレビュー"
           }
         }
       }
@@ -2734,6 +3682,12 @@
             "state" : "translated",
             "value" : "上一個"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "前へ"
+          }
         }
       }
     },
@@ -2751,6 +3705,12 @@
             "state" : "translated",
             "value" : "退出時總是保留視窗"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "終了時に常にウインドウを保持"
+          }
         }
       }
     },
@@ -2764,6 +3724,12 @@
           }
         },
         "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "引用"
+          }
+        },
+        "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "引用"
@@ -2785,6 +3751,12 @@
             "state" : "translated",
             "value" : "閱讀時間"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "読了時間"
+          }
         }
       }
     },
@@ -2801,6 +3773,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "最近的搜尋"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最近の検索"
           }
         }
       }
@@ -2819,6 +3797,12 @@
             "state" : "translated",
             "value" : "最近使用"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最近使用した項目"
+          }
         }
       }
     },
@@ -2835,6 +3819,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "減少透明度："
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "透明度を下げる:"
           }
         }
       }
@@ -2853,6 +3843,12 @@
             "state" : "translated",
             "value" : "重新整理"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更新"
+          }
         }
       }
     },
@@ -2869,6 +3865,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "重新整理中…"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更新中…"
           }
         }
       }
@@ -2887,6 +3889,12 @@
             "state" : "translated",
             "value" : "正規表示法"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正規表現"
+          }
         }
       }
     },
@@ -2903,6 +3911,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "重新啟動"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "再度開く"
           }
         }
       }
@@ -2921,6 +3935,12 @@
             "state" : "translated",
             "value" : "重新啟動 MarkEdit 以開始使用“%@”。"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "“%@”の使用を開始するにはMarkEditを再度開いてください。"
+          }
         }
       }
     },
@@ -2937,6 +3957,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "重新啟動 MarkEdit 以使用更新後的擴充功能。"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アップデートした機能拡張を使用するにはMarkEditを再度開いてください。"
           }
         }
       }
@@ -2955,6 +3981,12 @@
             "state" : "translated",
             "value" : "重新啟動以套用變更。"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "変更を適用するにはアプリを再度開いてください。"
+          }
         }
       }
     },
@@ -2971,6 +4003,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "寬鬆"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "広め"
           }
         }
       }
@@ -2989,6 +4027,12 @@
             "state" : "translated",
             "value" : "稍後提醒我"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "あとで通知"
+          }
         }
       }
     },
@@ -3005,6 +4049,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "移除工具列模糊效果"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ツールバーのぼかしを取り除く"
           }
         }
       }
@@ -3023,6 +4073,12 @@
             "state" : "translated",
             "value" : "渲染不可見字元："
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不可視文字の表示:"
+          }
         }
       }
     },
@@ -3039,6 +4095,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "取代"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "置換"
           }
         }
       }
@@ -3057,6 +4119,12 @@
             "state" : "translated",
             "value" : "全部取代"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "すべて置換"
+          }
         }
       }
     },
@@ -3073,6 +4141,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "在所選範圍中全部取代"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選択範囲内をすべて置換"
           }
         }
       }
@@ -3091,6 +4165,12 @@
             "state" : "translated",
             "value" : "重試"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "再試行"
+          }
         }
       }
     },
@@ -3107,6 +4187,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "顯示"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Finderに表示"
           }
         }
       }
@@ -3125,6 +4211,12 @@
             "state" : "translated",
             "value" : "回復成此版本"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "このバージョンに戻す"
+          }
         }
       }
     },
@@ -3140,6 +4232,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "儲存改動"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "変更を保存"
           }
         }
       }
@@ -3158,6 +4256,12 @@
             "state" : "translated",
             "value" : "搜尋"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "検索"
+          }
         }
       }
     },
@@ -3174,6 +4278,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "搜尋操作"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "検索アクション"
           }
         }
       }
@@ -3192,6 +4302,12 @@
             "state" : "translated",
             "value" : "全選"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "すべてを選択"
+          }
         }
       }
     },
@@ -3208,6 +4324,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "在所選範圍中進行全選"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選択範囲内をすべて選択"
           }
         }
       }
@@ -3226,6 +4348,12 @@
             "state" : "translated",
             "value" : "選擇所有相同項"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "すべての出現箇所を選択"
+          }
         }
       }
     },
@@ -3242,6 +4370,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "選擇…"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選択…"
           }
         }
       }
@@ -3260,6 +4394,12 @@
             "state" : "translated",
             "value" : "已選擇"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選択済み"
+          }
         }
       }
     },
@@ -3276,6 +4416,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "選中區域"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選択範囲"
           }
         }
       }
@@ -3294,6 +4440,12 @@
             "state" : "translated",
             "value" : "選擇狀態"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選択状況"
+          }
         }
       }
     },
@@ -3310,6 +4462,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "句子數量"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文数"
           }
         }
       }
@@ -3328,6 +4486,12 @@
             "state" : "translated",
             "value" : "分享此文件"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "この書類を共有"
+          }
         }
       }
     },
@@ -3344,6 +4508,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "顯示可用更新"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "利用可能なアップデートを表示"
           }
         }
       }
@@ -3362,6 +4532,12 @@
             "state" : "translated",
             "value" : "顯示隱藏檔案"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不可視ファイルを表示"
+          }
         }
       }
     },
@@ -3378,6 +4554,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "顯示書寫工具"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "作文ツールを表示"
           }
         }
       }
@@ -3396,6 +4578,12 @@
             "state" : "translated",
             "value" : "顯示："
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "表示:"
+          }
         }
       }
     },
@@ -3412,6 +4600,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "跳過這個版本"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "このバージョンをスキップ"
           }
         }
       }
@@ -3430,6 +4624,12 @@
             "state" : "translated",
             "value" : "標準單字"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "標準の単語"
+          }
         }
       }
     },
@@ -3446,6 +4646,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "統計數字"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "統計"
           }
         }
       }
@@ -3464,6 +4670,12 @@
             "state" : "translated",
             "value" : "刪除線"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取り消し線"
+          }
         }
       }
     },
@@ -3480,6 +4692,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "提交擴充功能…"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "機能拡張を提出…"
           }
         }
       }
@@ -3498,6 +4716,12 @@
             "state" : "translated",
             "value" : "鍵入時提供補全"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "入力中に候補を表示"
+          }
         }
       }
     },
@@ -3514,6 +4738,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "系統"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "システム"
           }
         }
       }
@@ -3532,6 +4762,12 @@
             "state" : "translated",
             "value" : "系統預設"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "システムデフォルト"
+          }
         }
       }
     },
@@ -3548,6 +4784,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "系統等寬"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "システム等幅"
           }
         }
       }
@@ -3566,6 +4808,12 @@
             "state" : "translated",
             "value" : "系統圓潤"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "システム角丸"
+          }
         }
       }
     },
@@ -3582,6 +4830,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "系統襯線"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "システムセリフ"
           }
         }
       }
@@ -3600,6 +4854,12 @@
             "state" : "translated",
             "value" : "制表鍵："
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tabキー:"
+          }
         }
       }
     },
@@ -3616,6 +4876,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "標籤模式："
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タブモード:"
           }
         }
       }
@@ -3634,6 +4900,12 @@
             "state" : "translated",
             "value" : "表格"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "表"
+          }
         }
       }
     },
@@ -3650,6 +4922,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "內容目錄"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目次"
           }
         }
       }
@@ -3668,6 +4946,12 @@
             "state" : "translated",
             "value" : "文字編碼："
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "テキストエンコーディング:"
+          }
         }
       }
     },
@@ -3684,6 +4968,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "文字格式"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "テキストフォーマット"
           }
         }
       }
@@ -3702,6 +4992,12 @@
             "state" : "translated",
             "value" : "無法下載或驗證該擴充功能。"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "機能拡張をダウンロードまたは検証できませんでした。"
+          }
         }
       }
     },
@@ -3718,6 +5014,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "此操作無法被撤銷。"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "この操作は取り消せません。"
           }
         }
       }
@@ -3736,6 +5038,12 @@
             "state" : "translated",
             "value" : "此擴充功能需要 MarkEdit %@ 或更高版本。"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "この機能拡張にはMarkEdit %@以降が必要です。"
+          }
         }
       }
     },
@@ -3752,6 +5060,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "此擴充功能擁有對編輯器的完整取用權限。"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "この機能拡張はエディタへのフルアクセスで実行されます。"
           }
         }
       }
@@ -3770,6 +5084,12 @@
             "state" : "translated",
             "value" : "此更新需要 macOS %@ 或更高版本，在升級您的系統版本之前無法安裝。"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "このリリースにはmacOS %@以降が必要です。オペレーティングシステムをアップグレードしないとインストールできません。"
+          }
         }
       }
     },
@@ -3786,6 +5106,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "這會從指令碼目錄中移除它的指令碼。"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "スクリプトフォルダからこの機能拡張のスクリプトが削除されます。"
           }
         }
       }
@@ -3804,6 +5130,12 @@
             "state" : "translated",
             "value" : "此來源未經 MarkEdit 審核，請僅在信任該來源時繼續。"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "この提供元はMarkEditによる審査を受けていません。信頼できる場合のみ続けてください。"
+          }
         }
       }
     },
@@ -3820,6 +5152,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "緊湊"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "狭め"
           }
         }
       }
@@ -3838,6 +5176,12 @@
             "state" : "translated",
             "value" : "標題"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タイトル"
+          }
         }
       }
     },
@@ -3854,6 +5198,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "切換列表"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リストを切り替える"
           }
         }
       }
@@ -3872,6 +5222,12 @@
             "state" : "translated",
             "value" : "工具列模式："
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ツールバーモード:"
+          }
         }
       }
     },
@@ -3888,6 +5244,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "尾部空白"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "行末"
           }
         }
       }
@@ -3906,6 +5268,12 @@
             "state" : "translated",
             "value" : "移除尾部空白"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "行末の空白を削除"
+          }
         }
       }
     },
@@ -3923,6 +5291,12 @@
             "state" : "translated",
             "value" : "關閉後仍保留擴充功能，但使其不啟用"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オフにすると、機能拡張をインストールしたまま無効にします"
+          }
         }
       }
     },
@@ -3936,6 +5310,12 @@
           }
         },
         "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "展開"
+          }
+        },
+        "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "展開"
@@ -3957,6 +5337,12 @@
             "state" : "translated",
             "value" : "展開行"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "行を展開"
+          }
         }
       }
     },
@@ -3973,6 +5359,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "展開的行"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "展開された行"
           }
         }
       }
@@ -3991,6 +5383,12 @@
             "state" : "translated",
             "value" : "解除安裝"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アンインストール"
+          }
         }
       }
     },
@@ -4007,6 +5405,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "要解除安裝“%@”嗎？"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "“%@”をアンインストールしますか?"
           }
         }
       }
@@ -4025,6 +5429,12 @@
             "state" : "translated",
             "value" : "更新"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アップデート"
+          }
         }
       }
     },
@@ -4041,6 +5451,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "全部更新"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "すべてアップデート"
           }
         }
       }
@@ -4059,6 +5475,12 @@
             "state" : "translated",
             "value" : "自動更新"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動的にアップデート"
+          }
         }
       }
     },
@@ -4076,6 +5498,12 @@
             "state" : "translated",
             "value" : "更新行為"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アップデート動作"
+          }
         }
       }
     },
@@ -4091,6 +5519,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "更新檔案內容"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ファイルの内容を更新"
           }
         }
       }
@@ -4109,6 +5543,12 @@
             "state" : "translated",
             "value" : "使用 ${content} 更新檔案"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "${content}でファイルを更新"
+          }
         }
       }
     },
@@ -4125,6 +5565,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "更新到 %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@にアップデート"
           }
         }
       }
@@ -4143,6 +5589,12 @@
             "state" : "translated",
             "value" : "更新"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アップデート"
+          }
         }
       }
     },
@@ -4158,6 +5610,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "更新當前活躍檔案的內容，沒有開啟的編輯器時將丟擲異常。"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アクティブな書類のファイル内容を更新します。エディタが開いていない場合はエラーになります。"
           }
         }
       }
@@ -4176,6 +5634,12 @@
             "state" : "translated",
             "value" : "更新中…"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アップデート中…"
+          }
         }
       }
     },
@@ -4192,6 +5656,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "檢視釋出頁面"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リリースページを表示"
           }
         }
       }
@@ -4210,6 +5680,12 @@
             "state" : "translated",
             "value" : "新功能"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新機能"
+          }
         }
       }
     },
@@ -4225,6 +5701,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "整個文件"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "書類全体"
           }
         }
       }
@@ -4243,6 +5725,12 @@
             "state" : "translated",
             "value" : "整詞尋找"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "単語全体"
+          }
         }
       }
     },
@@ -4259,6 +5747,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "視窗"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ウインドウ"
           }
         }
       }
@@ -4277,6 +5771,12 @@
             "state" : "translated",
             "value" : "視窗恢復："
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ウインドウの復元:"
+          }
         }
       }
     },
@@ -4293,6 +5793,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Windows (CRLF)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Windows（CRLF）"
           }
         }
       }
@@ -4311,6 +5817,12 @@
             "state" : "translated",
             "value" : "單字數量"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "単語数"
+          }
         }
       }
     },
@@ -4327,6 +5839,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "文件中的單字"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "書類内の単語"
           }
         }
       }
@@ -4345,6 +5863,12 @@
             "state" : "translated",
             "value" : "按編輯器的寬度換行"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "エディタの幅で行を折り返す"
+          }
         }
       }
     },
@@ -4361,6 +5885,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "書寫工具"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "作文ツール"
           }
         }
       }
@@ -4385,6 +5915,12 @@
             "state" : "translated",
             "value" : "“%1$@”型別的副檔名錯誤，請使用“.%2$@”。"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "種類“%1$@”のファイル拡張子が正しくありません。代わりに“.%2$@”を使用してください。"
+          }
         }
       }
     },
@@ -4401,6 +5937,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "您已安裝最新版本！"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最新です!"
           }
         }
       }

--- a/MarkEditMac/mul.lproj/Main.xcstrings
+++ b/MarkEditMac/mul.lproj/Main.xcstrings
@@ -86,7 +86,7 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "クリップボードから新規ファイル"
+            "value" : "クリップボードから新規作成"
           }
         }
       }
@@ -1882,7 +1882,7 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "読み出し専用モード"
+            "value" : "読み取り専用モード"
           }
         }
       }
@@ -2615,7 +2615,7 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "HTMLに書き出す"
+            "value" : "HTMLとして書き出す"
           }
         }
       }
@@ -3348,7 +3348,7 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "PDFに書き出す"
+            "value" : "PDFとして書き出す"
           }
         }
       }
@@ -3408,7 +3408,7 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "EPUBに書き出す"
+            "value" : "EPUBとして書き出す"
           }
         }
       }
@@ -3918,7 +3918,7 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "RTFに書き出す"
+            "value" : "RTFとして書き出す"
           }
         }
       }
@@ -4068,7 +4068,7 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "閉じたタブを再度開く"
+            "value" : "最後に閉じたタブを開く"
           }
         }
       }
@@ -4158,7 +4158,7 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "履歴バージョンを消去"
+            "value" : "バージョン履歴を消去"
           }
         }
       }
@@ -4668,7 +4668,7 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Word（DOCX）に書き出す"
+            "value" : "Word（DOCX）として書き出す"
           }
         }
       }
@@ -4698,7 +4698,7 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "問題トラッカー"
+            "value" : "問題を報告"
           }
         }
       }
@@ -5148,7 +5148,7 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "要素を調査"
+            "value" : "要素の詳細を表示"
           }
         }
       }
@@ -5448,7 +5448,7 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "履歴バージョンを消去"
+            "value" : "バージョン履歴を消去"
           }
         }
       }

--- a/MarkEditMac/mul.lproj/Main.xcstrings
+++ b/MarkEditMac/mul.lproj/Main.xcstrings
@@ -22,6 +22,12 @@
             "state" : "translated",
             "value" : "保持在頂部"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "常に手前に表示"
+          }
         }
       }
     },
@@ -45,6 +51,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "版本紀錄"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "バージョン履歴"
           }
         }
       }
@@ -70,6 +82,12 @@
             "state" : "translated",
             "value" : "從剪貼簿新建"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "クリップボードから新規ファイル"
+          }
         }
       }
     },
@@ -93,6 +111,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "尋找"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "検索"
           }
         }
       }
@@ -118,6 +142,12 @@
             "state" : "translated",
             "value" : "自定工具列…"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ツールバーをカスタマイズ…"
+          }
         }
       }
     },
@@ -138,6 +168,12 @@
           }
         },
         "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "MarkEdit"
+          }
+        },
+        "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "MarkEdit"
@@ -166,6 +202,12 @@
             "state" : "translated",
             "value" : "上次編輯三個月前"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "3か月前に編集"
+          }
         }
       }
     },
@@ -189,6 +231,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "轉換"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "変換"
           }
         }
       }
@@ -214,6 +262,12 @@
             "state" : "translated",
             "value" : "拼字"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "スペル"
+          }
         }
       }
     },
@@ -237,6 +291,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "語音"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "スピーチ"
           }
         }
       }
@@ -262,6 +322,12 @@
             "state" : "translated",
             "value" : "尋找"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "検索"
+          }
         }
       }
     },
@@ -285,6 +351,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "進入全螢幕"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "フルスクリーンにする"
           }
         }
       }
@@ -310,6 +382,12 @@
             "state" : "translated",
             "value" : "結束 MarkEdit"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "MarkEditを終了"
+          }
         }
       }
     },
@@ -333,6 +411,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "拷貝路徑"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "パスをコピー"
           }
         }
       }
@@ -358,6 +442,12 @@
             "state" : "translated",
             "value" : "關於 MarkEdit"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "MarkEditについて"
+          }
         }
       }
     },
@@ -381,6 +471,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "編輯"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "編集"
           }
         }
       }
@@ -406,6 +502,12 @@
             "state" : "translated",
             "value" : "全部儲存"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "すべてを保存"
+          }
         }
       }
     },
@@ -430,6 +532,12 @@
             "state" : "translated",
             "value" : "標題"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "見出し"
+          }
         }
       }
     },
@@ -453,6 +561,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "重做"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "やり直す"
           }
         }
       }
@@ -491,6 +605,12 @@
             "state" : "translated",
             "value" : "行尾格式"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "改行コード"
+          }
         }
       }
     },
@@ -511,6 +631,12 @@
           }
         },
         "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "引用"
+          }
+        },
+        "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "引用"
@@ -539,6 +665,12 @@
             "state" : "translated",
             "value" : "替代"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動置換"
+          }
         }
       }
     },
@@ -562,6 +694,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "操作指令"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "コマンド"
           }
         }
       }
@@ -587,6 +725,12 @@
             "state" : "translated",
             "value" : "智慧型拷貝/貼上"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "スマートコピー/ペースト"
+          }
         }
       }
     },
@@ -610,6 +754,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "拷貝 Pandoc 指令"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pandocコマンドをコピー"
           }
         }
       }
@@ -635,6 +785,12 @@
             "state" : "translated",
             "value" : "自動修正拼字"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "スペルを自動的に修正"
+          }
         }
       }
     },
@@ -658,6 +814,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Classic Mac OS (CR)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Classic Mac OS（CR）"
           }
         }
       }
@@ -683,6 +845,12 @@
             "state" : "translated",
             "value" : "列表"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リスト"
+          }
         }
       }
     },
@@ -706,6 +874,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "向下移動行"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "行を下に移動"
           }
         }
       }
@@ -731,6 +905,12 @@
             "state" : "translated",
             "value" : "開發指南"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開発ガイド"
+          }
         }
       }
     },
@@ -754,6 +934,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "列印…"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "プリント…"
           }
         }
       }
@@ -779,6 +965,12 @@
             "state" : "translated",
             "value" : "視窗"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ウインドウ"
+          }
         }
       }
     },
@@ -802,6 +994,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "主選單"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "メインメニュー"
           }
         }
       }
@@ -827,6 +1025,12 @@
             "state" : "translated",
             "value" : "上次編輯兩周前"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2週間前に編集"
+          }
         }
       }
     },
@@ -850,6 +1054,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "三級標題"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "見出し3"
           }
         }
       }
@@ -875,6 +1085,12 @@
             "state" : "translated",
             "value" : "檔案"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ファイル"
+          }
         }
       }
     },
@@ -898,6 +1114,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "保留最多 100 個版本"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最大100バージョンを保持"
           }
         }
       }
@@ -923,6 +1145,12 @@
             "state" : "translated",
             "value" : "插入連結"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リンクを挿入"
+          }
         }
       }
     },
@@ -943,6 +1171,12 @@
           }
         },
         "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "設定…"
+          }
+        },
+        "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "設定…"
@@ -971,6 +1205,12 @@
             "state" : "translated",
             "value" : "檢索所選內容"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選択部分を検索に使用"
+          }
         }
       }
     },
@@ -995,6 +1235,12 @@
             "state" : "translated",
             "value" : "統計數字"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "統計"
+          }
         }
       }
     },
@@ -1018,6 +1264,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "儲存為…"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "別名で保存…"
           }
         }
       }
@@ -1056,6 +1308,12 @@
             "state" : "translated",
             "value" : "內容目錄"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目次"
+          }
         }
       }
     },
@@ -1079,6 +1337,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "檔案路徑"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ファイルのパス"
           }
         }
       }
@@ -1104,6 +1368,12 @@
             "state" : "translated",
             "value" : "轉換"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "変換"
+          }
         }
       }
     },
@@ -1127,6 +1397,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "視窗"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ウインドウ"
           }
         }
       }
@@ -1152,6 +1428,12 @@
             "state" : "translated",
             "value" : "縮小"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "小さく"
+          }
         }
       }
     },
@@ -1175,6 +1457,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "打字機模式"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タイプライターモード"
           }
         }
       }
@@ -1200,6 +1488,12 @@
             "state" : "translated",
             "value" : "智慧型連結"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "スマートリンク"
+          }
         }
       }
     },
@@ -1223,6 +1517,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "小寫"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "小文字にする"
           }
         }
       }
@@ -1248,6 +1548,12 @@
             "state" : "translated",
             "value" : "新增標籤"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新規タブ"
+          }
         }
       }
     },
@@ -1271,6 +1577,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "檔案"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ファイル"
           }
         }
       }
@@ -1296,6 +1608,12 @@
             "state" : "translated",
             "value" : "還原"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取り消す"
+          }
         }
       }
     },
@@ -1319,6 +1637,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "拼字和文法檢查"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "スペルと文法"
           }
         }
       }
@@ -1344,6 +1668,12 @@
             "state" : "translated",
             "value" : "結束"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "閉じる"
+          }
         }
       }
     },
@@ -1367,6 +1697,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "待辦"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ToDo"
           }
         }
       }
@@ -1392,6 +1728,12 @@
             "state" : "translated",
             "value" : "行尾格式"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "改行コード"
+          }
         }
       }
     },
@@ -1415,6 +1757,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "字體"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "フォント"
           }
         }
       }
@@ -1440,6 +1788,12 @@
             "state" : "translated",
             "value" : "所有本地版本"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "すべてのローカルバージョン"
+          }
         }
       }
     },
@@ -1463,6 +1817,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "放大"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "大きく"
           }
         }
       }
@@ -1488,6 +1848,12 @@
             "state" : "translated",
             "value" : "表格"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "表"
+          }
         }
       }
     },
@@ -1511,6 +1877,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "只讀模式"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "読み出し専用モード"
           }
         }
       }
@@ -1536,6 +1908,12 @@
             "state" : "translated",
             "value" : "輔助說明"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ヘルプ"
+          }
         }
       }
     },
@@ -1559,6 +1937,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "替代"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動置換"
           }
         }
       }
@@ -1584,6 +1968,12 @@
             "state" : "translated",
             "value" : "MarkEdit 輔助說明"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "MarkEditヘルプ"
+          }
         }
       }
     },
@@ -1607,6 +1997,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "開啟文件目錄"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "書類フォルダを開く"
           }
         }
       }
@@ -1632,6 +2028,12 @@
             "state" : "translated",
             "value" : "選擇上個章節"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "前のセクションを選択"
+          }
         }
       }
     },
@@ -1655,6 +2057,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "使用應用打開…"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "このアプリケーションで開く…"
           }
         }
       }
@@ -1680,6 +2088,12 @@
             "state" : "translated",
             "value" : "六級標題"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "見出し6"
+          }
         }
       }
     },
@@ -1704,6 +2118,12 @@
             "state" : "translated",
             "value" : "重置為預設"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "デフォルトに戻す"
+          }
         }
       }
     },
@@ -1727,6 +2147,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "後退"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "戻る"
           }
         }
       }
@@ -1765,6 +2191,12 @@
             "state" : "translated",
             "value" : "貼上"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ペースト"
+          }
         }
       }
     },
@@ -1788,6 +2220,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "在 Finder 中找到"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Finderに表示"
           }
         }
       }
@@ -1813,6 +2251,12 @@
             "state" : "translated",
             "value" : "顯示方式"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "表示"
+          }
         }
       }
     },
@@ -1836,6 +2280,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "顯示拼字和文法檢查"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "スペルと文法を表示"
           }
         }
       }
@@ -1861,6 +2311,12 @@
             "state" : "translated",
             "value" : "替代文字"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "テキストの置換"
+          }
         }
       }
     },
@@ -1884,6 +2340,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "上次編輯六個月前"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "6か月前に編集"
           }
         }
       }
@@ -1909,6 +2371,12 @@
             "state" : "translated",
             "value" : "智慧型引號"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "スマート引用符"
+          }
         }
       }
     },
@@ -1932,6 +2400,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "授予目錄許可權"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "フォルダへのアクセスを許可"
           }
         }
       }
@@ -1957,6 +2431,12 @@
             "state" : "translated",
             "value" : "顯示方式"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "表示"
+          }
         }
       }
     },
@@ -1980,6 +2460,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "立即檢查文件"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "書類を今すぐチェック"
           }
         }
       }
@@ -2005,6 +2491,12 @@
             "state" : "translated",
             "value" : "服務"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "サービス"
+          }
         }
       }
     },
@@ -2025,6 +2517,12 @@
           }
         },
         "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "縮小"
+          }
+        },
+        "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "縮小"
@@ -2053,6 +2551,12 @@
             "state" : "translated",
             "value" : "打開…"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開く…"
+          }
         }
       }
     },
@@ -2076,6 +2580,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "程式碼"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "コード"
           }
         }
       }
@@ -2101,6 +2611,12 @@
             "state" : "translated",
             "value" : "輸出為 HTML"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "HTMLに書き出す"
+          }
         }
       }
     },
@@ -2124,6 +2640,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "選擇整行"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "行を選択"
           }
         }
       }
@@ -2149,6 +2671,12 @@
             "state" : "translated",
             "value" : "打開選單"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "メニューを開く"
+          }
         }
       }
     },
@@ -2172,6 +2700,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "授予目錄許可權"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "フォルダへのアクセスを許可"
           }
         }
       }
@@ -2197,6 +2731,12 @@
             "state" : "translated",
             "value" : "自定義指南"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "カスタマイズガイド"
+          }
         }
       }
     },
@@ -2220,6 +2760,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "拷貝路徑"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "パスをコピー"
           }
         }
       }
@@ -2245,6 +2791,12 @@
             "state" : "translated",
             "value" : "向上移動行"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "行を上に移動"
+          }
         }
       }
     },
@@ -2268,6 +2820,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "斜體"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "イタリック"
           }
         }
       }
@@ -2293,6 +2851,12 @@
             "state" : "translated",
             "value" : "復原到已儲存版本"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最後に保存した状態に戻す"
+          }
         }
       }
     },
@@ -2316,6 +2880,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "顯示全部"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "すべてを表示"
           }
         }
       }
@@ -2341,6 +2911,12 @@
             "state" : "translated",
             "value" : "一級標題"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "見出し1"
+          }
         }
       }
     },
@@ -2364,6 +2940,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "開發者"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開発"
           }
         }
       }
@@ -2389,6 +2971,12 @@
             "state" : "translated",
             "value" : "將此程式所有視窗移至最前"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "すべてを手前に移動"
+          }
         }
       }
     },
@@ -2412,6 +3000,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "格式"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "フォーマット"
           }
         }
       }
@@ -2437,6 +3031,12 @@
             "state" : "translated",
             "value" : "Windows (CRLF)"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Windows（CRLF）"
+          }
         }
       }
     },
@@ -2460,6 +3060,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "管理擴充功能…"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "機能拡張を管理…"
           }
         }
       }
@@ -2485,6 +3091,12 @@
             "state" : "translated",
             "value" : "擴充功能"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "機能拡張"
+          }
         }
       }
     },
@@ -2508,6 +3120,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "檢查拼字文法"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "スペルと一緒に文法をチェック"
           }
         }
       }
@@ -2546,6 +3164,12 @@
             "state" : "translated",
             "value" : "補全"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "単語入力補完"
+          }
         }
       }
     },
@@ -2569,6 +3193,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "插入圖片"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "画像を挿入"
           }
         }
       }
@@ -2594,6 +3224,12 @@
             "state" : "translated",
             "value" : "擴充功能"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "機能拡張"
+          }
         }
       }
     },
@@ -2617,6 +3253,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "服務"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "サービス"
           }
         }
       }
@@ -2642,6 +3284,12 @@
             "state" : "translated",
             "value" : "打開最近使用過的檔案"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最近使った項目を開く"
+          }
         }
       }
     },
@@ -2665,6 +3313,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "切換塊註解"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ブロックコメントを切り替える"
           }
         }
       }
@@ -2690,6 +3344,12 @@
             "state" : "translated",
             "value" : "輸出為 PDF"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PDFに書き出す"
+          }
         }
       }
     },
@@ -2713,6 +3373,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "隱藏 MarkEdit"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "MarkEditを非表示"
           }
         }
       }
@@ -2738,6 +3404,12 @@
             "state" : "translated",
             "value" : "輸出為 EPUB"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "EPUBに書き出す"
+          }
         }
       }
     },
@@ -2761,6 +3433,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "放大"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "拡大"
           }
         }
       }
@@ -2786,6 +3464,12 @@
             "state" : "translated",
             "value" : "尋找上一個"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "前を検索"
+          }
         }
       }
     },
@@ -2809,6 +3493,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "縮到最小"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "しまう"
           }
         }
       }
@@ -2834,6 +3524,12 @@
             "state" : "translated",
             "value" : "停止朗讀"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "読み上げを停止"
+          }
         }
       }
     },
@@ -2857,6 +3553,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "水平分割線"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "水平線"
           }
         }
       }
@@ -2882,6 +3584,12 @@
             "state" : "translated",
             "value" : "四級標題"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "見出し4"
+          }
         }
       }
     },
@@ -2905,6 +3613,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "切換行註解"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "行コメントを切り替える"
           }
         }
       }
@@ -2930,6 +3644,12 @@
             "state" : "translated",
             "value" : "刪除"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "削除"
+          }
         }
       }
     },
@@ -2953,6 +3673,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "上次編輯一年前"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1年前に編集"
           }
         }
       }
@@ -2978,6 +3704,12 @@
             "state" : "translated",
             "value" : "向上拷貝行"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "行を上にコピー"
+          }
         }
       }
     },
@@ -3001,6 +3733,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "儲存…"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保存…"
           }
         }
       }
@@ -3026,6 +3764,12 @@
             "state" : "translated",
             "value" : "尋找下一個"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "次を検索"
+          }
         }
       }
     },
@@ -3049,6 +3793,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "設定頁面…"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ページ設定…"
           }
         }
       }
@@ -3074,6 +3824,12 @@
             "state" : "translated",
             "value" : "開發者"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開発"
+          }
         }
       }
     },
@@ -3097,6 +3853,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "macOS / Unix (LF)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "macOS / Unix（LF）"
           }
         }
       }
@@ -3122,6 +3884,12 @@
             "state" : "translated",
             "value" : "程式碼塊"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "コードブロック"
+          }
         }
       }
     },
@@ -3145,6 +3913,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "輸出為 RTF"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "RTFに書き出す"
           }
         }
       }
@@ -3170,6 +3944,12 @@
             "state" : "translated",
             "value" : "拷貝 Pandoc 指令"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pandocコマンドをコピー"
+          }
         }
       }
     },
@@ -3193,6 +3973,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "縮放"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "拡大/縮小"
           }
         }
       }
@@ -3218,6 +4004,12 @@
             "state" : "translated",
             "value" : "擴大選擇區域"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選択範囲を拡張"
+          }
         }
       }
     },
@@ -3241,6 +4033,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "在輸入時同步檢查拼字"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "入力中にスペルチェック"
           }
         }
       }
@@ -3266,6 +4064,12 @@
             "state" : "translated",
             "value" : "重新開啟關閉的標籤"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "閉じたタブを再度開く"
+          }
         }
       }
     },
@@ -3289,6 +4093,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "內容目錄"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目次"
           }
         }
       }
@@ -3314,6 +4124,12 @@
             "state" : "translated",
             "value" : "智慧型破折號"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "スマートダッシュ記号"
+          }
         }
       }
     },
@@ -3337,6 +4153,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "清理歷史版本"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "履歴バージョンを消去"
           }
         }
       }
@@ -3362,6 +4184,12 @@
             "state" : "translated",
             "value" : "二級標題"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "見出し2"
+          }
         }
       }
     },
@@ -3385,6 +4213,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "全選"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "すべてを選択"
           }
         }
       }
@@ -3410,6 +4244,12 @@
             "state" : "translated",
             "value" : "跳至所選範圍"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選択部分へジャンプ"
+          }
         }
       }
     },
@@ -3433,6 +4273,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "檢查更新…"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アップデートを確認…"
           }
         }
       }
@@ -3458,6 +4304,12 @@
             "state" : "translated",
             "value" : "以編碼重新打開"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "テキストエンコーディングを指定して再度開く"
+          }
         }
       }
     },
@@ -3481,6 +4333,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "塊狀公式"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "数式ブロック"
           }
         }
       }
@@ -3506,6 +4364,12 @@
             "state" : "translated",
             "value" : "實際大小"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "実際のサイズ"
+          }
         }
       }
     },
@@ -3529,6 +4393,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "視窗"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ウインドウ"
           }
         }
       }
@@ -3554,6 +4424,12 @@
             "state" : "translated",
             "value" : "五級標題"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "見出し5"
+          }
         }
       }
     },
@@ -3577,6 +4453,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "操作指令"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "コマンド"
           }
         }
       }
@@ -3602,6 +4484,12 @@
             "state" : "translated",
             "value" : "縮小選擇區域"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選択範囲を縮小"
+          }
         }
       }
     },
@@ -3625,6 +4513,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "使用應用打開…"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "このアプリケーションで開く…"
           }
         }
       }
@@ -3650,6 +4544,12 @@
             "state" : "translated",
             "value" : "打開最近使用過的檔案"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最近使った項目を開く"
+          }
         }
       }
     },
@@ -3673,6 +4573,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "向下拷貝行"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "行を下にコピー"
           }
         }
       }
@@ -3698,6 +4604,12 @@
             "state" : "translated",
             "value" : "大寫"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "語頭を大文字にする"
+          }
         }
       }
     },
@@ -3721,6 +4633,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "增加縮排"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "インデントを増やす"
           }
         }
       }
@@ -3746,6 +4664,12 @@
             "state" : "translated",
             "value" : "輸出為 Word Docx"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Word（DOCX）に書き出す"
+          }
         }
       }
     },
@@ -3770,6 +4694,12 @@
             "state" : "translated",
             "value" : "問題追蹤系統"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "問題トラッカー"
+          }
         }
       }
     },
@@ -3790,6 +4720,12 @@
           }
         },
         "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "MarkEdit"
+          }
+        },
+        "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "MarkEdit"
@@ -3818,6 +4754,12 @@
             "state" : "translated",
             "value" : "剪下"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "カット"
+          }
         }
       }
     },
@@ -3841,6 +4783,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "保留最多 50 個版本"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最大50バージョンを保持"
           }
         }
       }
@@ -3866,6 +4814,12 @@
             "state" : "translated",
             "value" : "隱藏其他"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ほかを非表示"
+          }
         }
       }
     },
@@ -3889,6 +4843,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "有序列表"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "番号付きリスト"
           }
         }
       }
@@ -3914,6 +4874,12 @@
             "state" : "translated",
             "value" : "選擇下個相同項"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "次の出現箇所を選択"
+          }
         }
       }
     },
@@ -3937,6 +4903,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "大寫"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "大文字にする"
           }
         }
       }
@@ -3962,6 +4934,12 @@
             "state" : "translated",
             "value" : "清除選單"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "メニューを消去"
+          }
         }
       }
     },
@@ -3985,6 +4963,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "字體"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "フォント"
           }
         }
       }
@@ -4010,6 +4994,12 @@
             "state" : "translated",
             "value" : "減少縮排"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "インデントを減らす"
+          }
         }
       }
     },
@@ -4033,6 +5023,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "編輯"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "編集"
           }
         }
       }
@@ -4058,6 +5054,12 @@
             "state" : "translated",
             "value" : "開啟文件目錄"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "書類フォルダを開く"
+          }
         }
       }
     },
@@ -4081,6 +5083,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "粗體"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ボールド"
           }
         }
       }
@@ -4106,6 +5114,12 @@
             "state" : "translated",
             "value" : "新增"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新規"
+          }
         }
       }
     },
@@ -4129,6 +5143,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "審查元素"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "要素を調査"
           }
         }
       }
@@ -4154,6 +5174,12 @@
             "state" : "translated",
             "value" : "跳轉到行…"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "指定行へ移動…"
+          }
         }
       }
     },
@@ -4177,6 +5203,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "行內公式"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "数式"
           }
         }
       }
@@ -4202,6 +5234,12 @@
             "state" : "translated",
             "value" : "輔助說明"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ヘルプ"
+          }
         }
       }
     },
@@ -4225,6 +5263,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "拷貝"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "コピー"
           }
         }
       }
@@ -4250,6 +5294,12 @@
             "state" : "translated",
             "value" : "以編碼重新打開"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "テキストエンコーディングを指定して再度開く"
+          }
         }
       }
     },
@@ -4273,6 +5323,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "語音"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "スピーチ"
           }
         }
       }
@@ -4298,6 +5354,12 @@
             "state" : "translated",
             "value" : "前進"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "進む"
+          }
         }
       }
     },
@@ -4321,6 +5383,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "尋找…"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "検索…"
           }
         }
       }
@@ -4346,6 +5414,12 @@
             "state" : "translated",
             "value" : "尋找與取代…"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "検索と置換…"
+          }
         }
       }
     },
@@ -4369,6 +5443,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "清理歷史版本"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "履歴バージョンを消去"
           }
         }
       }
@@ -4394,6 +5474,12 @@
             "state" : "translated",
             "value" : "開始朗讀"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "読み上げを開始"
+          }
         }
       }
     },
@@ -4417,6 +5503,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "上次編輯一個月前"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1か月前に編集"
           }
         }
       }
@@ -4442,6 +5534,12 @@
             "state" : "translated",
             "value" : "瞭解更多…"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "詳しい情報…"
+          }
         }
       }
     },
@@ -4465,6 +5563,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "格式"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "フォーマット"
           }
         }
       }
@@ -4490,6 +5594,12 @@
             "state" : "translated",
             "value" : "標題"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "見出し"
+          }
         }
       }
     },
@@ -4513,6 +5623,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "顯示替代視窗"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動置換を表示"
           }
         }
       }
@@ -4538,6 +5654,12 @@
             "state" : "translated",
             "value" : "刪除線"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取り消し線"
+          }
         }
       }
     },
@@ -4561,6 +5683,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "選擇下個章節"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "次のセクションを選択"
           }
         }
       }
@@ -4586,6 +5714,12 @@
             "state" : "translated",
             "value" : "選擇所有相同項"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "すべての出現箇所を選択"
+          }
         }
       }
     },
@@ -4609,6 +5743,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "目錄路徑"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "フォルダのパス"
           }
         }
       }

--- a/QuickLookMac/Localizable.xcstrings
+++ b/QuickLookMac/Localizable.xcstrings
@@ -15,6 +15,12 @@
             "state" : "translated",
             "value" : "打開 MarkEdit 以完成設定。"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "設定を完了するにはMarkEditを開いてください。"
+          }
         }
       }
     }

--- a/QuickLookMac/Localizable.xcstrings
+++ b/QuickLookMac/Localizable.xcstrings
@@ -19,7 +19,7 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "設定を完了するにはMarkEditを開いてください。"
+            "value" : "設定を完了するには、MarkEditを開いてください。"
           }
         }
       }


### PR DESCRIPTION
## Summary

This pull request adds Japanese localization to MarkEdit while preserving English as the source language and keeping the existing Simplified and Traditional Chinese localizations unchanged.

When Japanese is selected as the preferred macOS language, MarkEdit displays its interface in Japanese. Other language environments continue to use the existing localizations and fallback behavior.

## Localization foundation

- Registers Japanese (`ja`) as a supported project region.
- Uses the project's existing String Catalogs rather than adding a separate localization system.
- Covers user-facing strings in the main app, menus, settings, tooltips, alerts, context menus, App Shortcuts, and the Quick Look extension.
- Leaves logs, debugging text, internal identifiers, keyboard identifiers, and other non-user-facing strings unchanged.
- Adds no runtime localization layer or startup work.

## Japanese translations

- Adds Japanese translations for all 450 currently translatable catalog entries.
- Uses standard Apple Japanese terminology for common macOS menu commands where applicable.
- Preserves format placeholders, plural rules, and String Catalog structure.
- Adds about 55 KiB of compiled Japanese localization data across the app and Quick Look extension.

## Validation

- Successfully built the macOS app and Quick Look extension with the Japanese catalogs.
- Validated the App Shortcuts catalog and confirmed that all currently translatable entries contain Japanese values.
- Confirmed that format placeholders are preserved.
- Confirmed that the English source strings and existing Chinese localizations remain unchanged.
- Reviewed the Japanese UI in the built app and compared standard menu terminology with the current macOS TextEdit and WebKit localizations.
- Confirmed that the compiled app contains the expected Japanese resources for menus, app strings, plurals, App Shortcuts, and Quick Look.

## Note

I apologize for the poor state of this pull request when it was first opened. The implementation, translations, and description have since been thoroughly reviewed and corrected. P-nutsK also reviewed the Japanese UI in the running app and found the wording natural throughout.
