### PR TITLE
Migrate to TypeScript 6

### DIFF
--- a/CoreEditor/package.json
+++ b/CoreEditor/package.json
@@ -5,9 +5,10 @@
   "scripts": {
     "dev": "vite",
     "lint": "eslint .",
+    "typecheck": "tsc",
     "codegen": "ts-gyb --config ./src/@codegen/config.json >/dev/null",
     "test": "jest",
-    "build": "yarn lint && yarn codegen && vite build"
+    "build": "yarn lint && yarn typecheck && yarn codegen && vite build"
   },
   "keywords": [],
   "author": "",
@@ -32,7 +33,7 @@
     "@eslint/js": "^9.39.0",
     "@stylistic/eslint-plugin": "^5.5.0",
     "@types/jest": "^29.5.4",
-    "@typescript-eslint/parser": "^8.46.2",
+    "@typescript-eslint/parser": "^8.67.0",
     "eslint": "^9.39.0",
     "eslint-plugin-compat": "^6.0.2",
     "eslint-plugin-promise": "^7.2.1",
@@ -43,8 +44,8 @@
     "ts-gyb": "^0.12.0",
     "ts-jest": "^29.4.5",
     "tslib": "^2.6.2",
-    "typescript": "^5.0.0",
-    "typescript-eslint": "^8.46.2",
+    "typescript": "^6.0.0",
+    "typescript-eslint": "^8.47.0",
     "vite": "^8.0.0",
     "vite-plugin-singlefile": "^2.3.3"
   },

--- a/CoreEditor/src/styling/views/index.ts
+++ b/CoreEditor/src/styling/views/index.ts
@@ -7,8 +7,7 @@ import { globalState } from '../../common/store';
  */
 export class PreviewWidget extends WidgetView {
   constructor(private readonly code: string, private readonly type: PreviewType, pos: number) {
-    super();
-    this.pos = pos;
+    super(pos);
   }
 
   toDOM() {
@@ -44,8 +43,7 @@ export class PreviewWidget extends WidgetView {
  */
 export class LineBreakWidget extends WidgetView {
   constructor(pos: number) {
-    super();
-    this.pos = pos;
+    super(pos);
   }
 
   toDOM() {

--- a/CoreEditor/src/styling/views/types.ts
+++ b/CoreEditor/src/styling/views/types.ts
@@ -4,5 +4,7 @@ import { WidgetType } from '@codemirror/view';
  * Extend WidgetType with a pos to indicate where to draw.
  */
 export abstract class WidgetView extends WidgetType {
-  pos: number;
+  constructor(readonly pos: number) {
+    super();
+  }
 }

--- a/CoreEditor/tsconfig.json
+++ b/CoreEditor/tsconfig.json
@@ -1,19 +1,20 @@
 {
   "compilerOptions": {
-    "typeRoots": ["./node_modules/@types", "./src/@types"],
-    "module": "esnext",
-    "target": "esnext",
-    "lib": ["esnext", "dom"],
-    "composite": true,
-    "noImplicitAny": true,
+    "target": "es2024",
+    "lib": ["es2024", "dom"],
+    "module": "preserve",
     "moduleResolution": "bundler",
     "esModuleInterop": true,
-    "strictNullChecks": true,
-    "importHelpers": true,
-    "skipLibCheck": true,
+    "types": ["node"],
+    "strict": true,
+    "noEmit": true,
+    "isolatedModules": true,
+    "noUncheckedSideEffectImports": true,
+    "forceConsistentCasingInFileNames": true,
     "paths": {
       "@codemirror/lang-html": ["./src/@vendor/lang-html"],
       "@codemirror/lang-markdown": ["./src/@vendor/lang-markdown"]
     }
-  }
+  },
+  "include": ["index.ts", "src/**/*.ts", "test/**/*.ts", "vite.config.mts"]
 }

--- a/CoreEditor/yarn.lock
+++ b/CoreEditor/yarn.lock
@@ -1629,7 +1629,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:8.67.0, @typescript-eslint/parser@npm:^8.46.2":
+"@typescript-eslint/parser@npm:8.67.0, @typescript-eslint/parser@npm:^8.67.0":
   version: 8.67.0
   resolution: "@typescript-eslint/parser@npm:8.67.0"
   dependencies:
@@ -4073,7 +4073,7 @@ __metadata:
     "@lezer/markdown": "npm:^1.0.0"
     "@stylistic/eslint-plugin": "npm:^5.5.0"
     "@types/jest": "npm:^29.5.4"
-    "@typescript-eslint/parser": "npm:^8.46.2"
+    "@typescript-eslint/parser": "npm:^8.67.0"
     eslint: "npm:^9.39.0"
     eslint-plugin-compat: "npm:^6.0.2"
     eslint-plugin-promise: "npm:^7.2.1"
@@ -4084,8 +4084,8 @@ __metadata:
     ts-gyb: "npm:^0.12.0"
     ts-jest: "npm:^29.4.5"
     tslib: "npm:^2.6.2"
-    typescript: "npm:^5.0.0"
-    typescript-eslint: "npm:^8.46.2"
+    typescript: "npm:^6.0.0"
+    typescript-eslint: "npm:^8.47.0"
     vite: "npm:^8.0.0"
     vite-plugin-singlefile: "npm:^2.3.3"
   languageName: unknown
@@ -5010,7 +5010,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript-eslint@npm:^8.46.2":
+"typescript-eslint@npm:^8.47.0":
   version: 8.67.0
   resolution: "typescript-eslint@npm:8.67.0"
   dependencies:
@@ -5035,13 +5035,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5.0.0":
-  version: 5.9.3
-  resolution: "typescript@npm:5.9.3"
+"typescript@npm:^6.0.0":
+  version: 6.0.3
+  resolution: "typescript@npm:6.0.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/6bd7552ce39f97e711db5aa048f6f9995b53f1c52f7d8667c1abdc1700c68a76a308f579cd309ce6b53646deb4e9a1be7c813a93baaf0a28ccd536a30270e1c5
+  checksum: 10c0/4a25ff5045b984370f48f196b3a0120779b1b343d40b9a68d114ea5e5fff099809b2bb777576991a63a5cd59cf7bffd96ff6fe10afcefbcb8bd6fb96ad4b6606
   languageName: node
   linkType: hard
 
@@ -5055,13 +5055,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A^5.0.0#optional!builtin<compat/typescript>":
-  version: 5.9.3
-  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
+"typescript@patch:typescript@npm%3A^6.0.0#optional!builtin<compat/typescript>":
+  version: 6.0.3
+  resolution: "typescript@patch:typescript@npm%3A6.0.3#optional!builtin<compat/typescript>::version=6.0.3&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/ad09fdf7a756814dce65bc60c1657b40d44451346858eea230e10f2e95a289d9183b6e32e5c11e95acc0ccc214b4f36289dcad4bf1886b0adb84d711d336a430
+  checksum: 10c0/2f25c74e65663c248fa1ade2b8459d9ce5372ff9dad07067310f132966ebec1d93f6c42f0baf77a6b6a7a91460463f708e6887013aaade22111037457c6b25df
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Using 6 instead of 7 is intentional for now because of dependency readiness.